### PR TITLE
Change sockjs endpoint URL format

### DIFF
--- a/SockJSAdapter.R
+++ b/SockJSAdapter.R
@@ -22,10 +22,7 @@ local({
    inject <- paste(
       tags$script(src='http://cdn.sockjs.org/sockjs-0.3.min.js'),
       tags$script(
-         sprintf(
-            'Shiny.createSocket = function() {return new SockJS("%s",null,{debug:true});};',
-            Sys.getenv('SHINY_SOCKJSPREFIX')
-         ),
+         'Shiny.createSocket = function() {return new SockJS(location.pathname + "__sockjs__",null,{debug:true});};',
          'Shiny.oncustommessage = function(message) {alert(message);};'
       ),
       gaTrackingCode,

--- a/lib/RMonitor.js
+++ b/lib/RMonitor.js
@@ -26,7 +26,7 @@ var abort = function(msg){
 process.send({status: 'ready'});
 
 process.on('message',function(m){
-   var i, spawnR, server, port, sockjsPrefix, gaTrackingId;
+   var i, spawnR, server, port, gaTrackingId;
    var userInfo = getpwnam(m.user);
 
    if (!userInfo){
@@ -45,7 +45,6 @@ process.on('message',function(m){
       abort("ALERT: Cannot chdir to "+userInfo.home+"/ShinyApps");
    }
 
-   sockjsPrefix = m.options.shinyOptions.sockjsPrefix;
    gaTrackingId = m.options.shinyOptions.googleAnalyticsTrackingId;
 
    spawnR = function() {
@@ -54,7 +53,6 @@ process.on('message',function(m){
 
       env.SHINY_PORT=port;
       env.SHINY_APP=m.app;
-      env.SHINY_SOCKJSPREFIX = '/' + m.user + '/' + m.app + '/sockjs';
       env.SHINY_GAID = gaTrackingId;
       env.SOCKJSADAPTER = process.env.SOCKJSADAPTER;
       env.USER=userInfo.username;

--- a/lib/shiny-server.js
+++ b/lib/shiny-server.js
@@ -287,7 +287,7 @@ ProxiedUserApp.prototype.sockjsOnConnectHandler = function(){
 
       self.addConnectedClient(sockjsClient,wsClient);
 
-      console.log("ws("+appDetails.hash+"): "+sockjsClient.remotePort+"<->"+wsClient._uri.port+" ws open");
+      // console.log("ws("+appDetails.hash+"): "+sockjsClient.remotePort+"<->"+wsClient._uri.port+" ws open");
 
       wsClient.onopen = function(event){
          wsIsOpen = true;
@@ -302,14 +302,14 @@ ProxiedUserApp.prototype.sockjsOnConnectHandler = function(){
       }
 
       wsClient.onmessage = function(event){
-         console.log("ws("+appDetails.hash+"): "+sockjsClient.remotePort+"<- "+wsClient._uri.port);
+         // console.log("ws("+appDetails.hash+"): "+sockjsClient.remotePort+"<- "+wsClient._uri.port);
          sockjsClient.write(event.data);
       };
 
       wsClient.onclose = function(event){
          var msg = ShinyProxyMessageToClient("The RWebSocket unexpectedly closed. Inspect your Shiny app and refresh your browser window.");
 
-         console.log("ws("+appDetails.hash+"): "+sockjsClient.remotePort+" ->"+wsClient._uri.port+" close");
+         // console.log("ws("+appDetails.hash+"): "+sockjsClient.remotePort+" ->"+wsClient._uri.port+" close");
 
          sockjsClient.write(msg);
          sockjsClient.close();
@@ -321,7 +321,7 @@ ProxiedUserApp.prototype.sockjsOnConnectHandler = function(){
       };
 
       sockjsClient.on('data', function(message) {
-         console.log("ws("+appDetails.hash+"): "+sockjsClient.remotePort+" ->"+wsClient._uri.port);
+         // console.log("ws("+appDetails.hash+"): "+sockjsClient.remotePort+" ->"+wsClient._uri.port);
          if (wsIsOpen){
             wsClient.send(message);
          } else {
@@ -330,7 +330,7 @@ ProxiedUserApp.prototype.sockjsOnConnectHandler = function(){
       });
 
       sockjsClient.on('close', function(message){
-         console.log("ws("+appDetails.hash+"): "+sockjsClient.remotePort+"<- "+wsClient._uri.port+" close");
+         // console.log("ws("+appDetails.hash+"): "+sockjsClient.remotePort+"<- "+wsClient._uri.port+" close");
          wsClient.close();
 
          // Do we need to call close here?
@@ -431,7 +431,7 @@ ProxiedUserApp.prototype.finishStartup = function(options){
 
    sockjsServer = sockjs.createServer();
    this.sockjsHandler = sockjsServer.listener(
-         {prefix: this.appDetails.rootUrl + '/sockjs'}).getHandler();
+         {prefix: this.appDetails.rootUrl + '/__sockjs__'}).getHandler();
 
    // metahandlers return a function when an object is pushed onto
    // the array. It disposes of the object.

--- a/shiny-server.conf.sample
+++ b/shiny-server.conf.sample
@@ -4,7 +4,4 @@
 
   // The URL to redirect to when the root URL is requested
   "homepageRedirect" : "http://www.rstudio.com/",
-
-  // URL prefix for sockjs (do not include trailing slash)
-  "sockjsPrefix" : "/sockjs"
 }


### PR DESCRIPTION
Currently, for app /jcheng/testapp, the sockjs path is /sockjs/jcheng/testapp. This change rearranges it so for the same app, the sockjs path is now /jcheng/testapp/**sockjs** . Not only does this simplify the getAppDetails code, but it also makes putting a proxy in front much easier because it's possible to basically use relative paths to refer to the sockjs endpoint.

(I say "basically" because we still end up forming an absolute path when newing up the SockJS client in the browser; for some reason websocket transports only seem to work with SockJS when using abs path.)
