### PR TITLE
Update templates/directoryIndex.html

### DIFF
--- a/templates/directoryIndex.html
+++ b/templates/directoryIndex.html
@@ -28,7 +28,7 @@
     <li><a class="code" href="{{this.url}}">{{this.name}}</a> (application)</li>
   {{/each}}
   {{#each dirs}}
-    <li><a class="code" href="{{this.url}}">{{this.name}}/</a></li>
+    <li><a class="code" href="{{this.url}}/">{{this.name}}/</a></li>
   {{/each}}
   {{#each files}}
     <li><a class="code" href="{{this.url}}">{{this.name}}</a></li>


### PR DESCRIPTION
Adding a / at the end of directory links makes shiny-server work with the apache mod_proxy module ProxyPass directive
