### PR TITLE
Redhat daemon fix

### DIFF
--- a/config/init.d/redhat/shiny-server
+++ b/config/init.d/redhat/shiny-server
@@ -9,6 +9,7 @@
 
 prog=shiny-server
 logfile="/var/log/${prog}"
+lockfile="/var/lock/subsys/${prog}"
 
 # Exit if the package is not installed
 [ -x "$prog" ] || exit 0


### PR DESCRIPTION
I've amended the daemon to log to a file and run in the background on Redhat.

Also, I've defined the missing `lockfile` variable.

Tested on Centos 5.5.
