### PR TITLE
Fix bug in debian init.d script

### DIFF
--- a/config/init.d/debian/shiny-server
+++ b/config/init.d/debian/shiny-server
@@ -40,9 +40,9 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon --start --quiet --exec $DAEMON --test > /dev/null \
+	start-stop-daemon --start --quiet --background --exec $DAEMON --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --quiet --exec $DAEMON \
+	start-stop-daemon --start --quiet --background --exec $DAEMON \
 		|| return 2
 }
 


### PR DESCRIPTION
Without --background option the system does not load anything after starting
shiny-server. This is not desirable behaviour, since if ssh starts after 
shiny-server (as it did in my case), you are left with broken system.
