### PR TITLE
make sockjs work when shiny-server is behind a reverse proxy that uses SSL

### DIFF
--- a/R/SockJSAdapter.R
+++ b/R/SockJSAdapter.R
@@ -45,7 +45,7 @@ local({
    }
 
    inject <- paste(
-      tags$script(src='http://cdn.sockjs.org/sockjs-0.3.min.js'),
+      tags$script(src='//d1fxtkz8shb9d2.cloudfront.net/sockjs-0.3.min.js'),
       tags$script(
         HTML(
           paste(

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -27,7 +27,7 @@ function createServer(router, workerRegistry) {
   // between the SockJS server connection and the worker websocket connection.
   var sockjsServer = sockjs.createServer({
     // TODO: make URL configurable
-    sockjs_url: 'http://cdn.sockjs.org/sockjs-0.3.min.js',
+    sockjs_url: '//d1fxtkz8shb9d2.cloudfront.net/sockjs-0.3.min.js',
     prefix: '.*/__sockjs__',
     log: function() {}
   });


### PR DESCRIPTION
In this case, including plain http urls will fail due to security restrictions in the browser. This patch uses the `//` notation for the urls as well as the cloudfront domain name instead of the sockjs.org cname.

see https://github.com/sockjs/sockjs-client#deployment
