### PR TITLE
upstart/init.d scripts should all run as shiny user

### DIFF
--- a/config/init.d/debian/shiny-server
+++ b/config/init.d/debian/shiny-server
@@ -18,7 +18,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="shiny server"
 NAME=shiny-server
-DAEMON=shiny-server
+DAEMON=/usr/bin/shiny-server
 SCRIPTNAME=/etc/init.d/shiny-server
 
 # Exit if the package is not installed
@@ -40,9 +40,9 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon --start --quiet --background --exec $DAEMON --test > /dev/null \
+	start-stop-daemon --start --quiet --background --user shiny --exec $DAEMON --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --quiet --background --exec $DAEMON \
+	start-stop-daemon --start --quiet --background --user shiny --exec $DAEMON \
 		|| return 2
 }
 

--- a/config/init.d/redhat/shiny-server
+++ b/config/init.d/redhat/shiny-server
@@ -21,7 +21,7 @@ fi
 start() {
     touch $logfile
     echo -n "Starting shiny-server: "
-    daemon $prog >> $logfile &
+    daemon --user shiny $prog >> $logfile &
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile

--- a/config/init.d/suse/shiny-server
+++ b/config/init.d/suse/shiny-server
@@ -23,7 +23,7 @@ case "$1" in
 
 	## Start daemon with startproc(8). If this fails
 	## the return value is set appropriately by startproc.
-	/sbin/startproc shiny-server
+	/sbin/startproc -u shiny shiny-server
 
 	# Remember status and be verbose
 	rc_status -v

--- a/config/upstart/shiny-server.conf
+++ b/config/upstart/shiny-server.conf
@@ -7,6 +7,6 @@ stop on runlevel [016]
 
 limit nofile 1000000 1000000
 
-exec shiny-server >> /var/log/shiny-server.log 2>&1
+exec start-stop-daemon --start -c shiny --exec /usr/bin/shiny-server >> /var/log/shiny-server.log 2>&1
 
 respawn


### PR DESCRIPTION
Tested on Ubuntu 13.04. Need to test on Debian, CentOS 5/6, Ubuntu 10.04, and Suse.
