### PR TITLE
This was originally reported under issue #70.

### DIFF
--- a/lib/scheduler/scheduler.js
+++ b/lib/scheduler/scheduler.js
@@ -297,7 +297,16 @@ function connectEndpoint_p(endpoint, timeout, shouldContinue) {
 
           return defer.resolve(appWorkerHandle);
           },
-          doReject
+          function(error) {
+            doReject(error);
+            //We spawned the worker but for whatever reason failed to connect to it.
+            //Kill the process to make sure it's not orphaned.
+            try {
+              appWorker.kill();
+            } catch(err) {
+              logger.error('Failed to kill process on ' + endpoint.toString() + ': ' + err.message);
+            }
+          }
         )
         .done();
 


### PR DESCRIPTION
My intuition as to what was the underlying issue was a bit off the mark.

Rather I believe that in the event that connectEndpoint_p fails to connect to a worker:

At this point, for this scheduler instance, after doReject, $workers[workerId].promise -> rejection, however if the worker never fulfills
its exit promise (it's stuck churning away for whatever reason), the scheduler instance remains hanging around
with ($workers[Object.keys(this.$workers)[0]].promise) still pointing at that rejection.
This would handicap all future requests pointing at this appSpec, in the simple-scheduler model.

Let me know if this doesn't make sense.

Thanks
