### PR TITLE
Upstart file

### DIFF
--- a/config/upstart/shiny-server.conf
+++ b/config/upstart/shiny-server.conf
@@ -10,4 +10,5 @@ limit nofile 1000000 1000000
 
 exec shiny-server --pidfile=/var/run/shiny-server.pid >> /var/log/shiny-server.log 2>&1
 
+post-stop exec sleep 5
 respawn


### PR DESCRIPTION
Added explicit language to conf. In R, use
`umlautOk = nlevels(na.omit(as.factor(iconv(c("Pre","Prä")))))==2`
to test if the settings are honored. Without this entry, processing of special characters (ä,ü) by Pandoc can also lead to hang or "subscript out of range" after several minutes processing.

Added post-stop sleep to delay respawning of upstart. On  some computers, too fast respawing fails, and shiny server is not started. This would better be a pre-start delay, but according to
http://askubuntu.com/questions/52309/respawning-too-fast-stopped-how-to-make-upstart-disable-for-5-mins there is no such option.
