### PR TITLE
Added support for single app.R deployments as supported in shiny 0.10.2.

### DIFF
--- a/lib/router/directory-router.js
+++ b/lib/router/directory-router.js
@@ -290,6 +290,9 @@ function DirectoryRouter(root, runas, dirIndex, prefix, logdir, settings,
                 var app = _.find(entries, function(entry) {
                   return /^server\.r$/i.test(entry);
                 });
+                var singleApp = _.find(entries, function(entry) {
+                  return /^app\.r$/i.test(entry);
+                });
                 var rmd = _.find(entries, function(entry) {
                   return /\.rmd$/i.test(entry);
                 });
@@ -309,7 +312,7 @@ function DirectoryRouter(root, runas, dirIndex, prefix, logdir, settings,
                 // Give priority to an Rmd index, the fall back to an html index
                 return {
                   exists: true, 
-                  isApp: !!app, 
+                  isApp: (!!app || !!singleApp), 
                   isRmd: !!rmd, 
                   indexType: indexRmd ? 'rmd' : indexHtm ? 'html' : null,
                   indexPath: indexRmd || indexHtm

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -229,6 +229,10 @@ function SingleAppRouter(appdir, runas, prefix, logDir, settings) {
       var app = _.find(files, function(entry) {
         return /^server\.r$/i.test(entry);
       });
+
+      var singleApp = _.find(files, function(entry) {
+        return /^app\.r$/i.test(entry);
+      });
       var rmd = _.find(files, function(entry) {
         return /\.rmd$/i.test(entry);
       });
@@ -248,7 +252,7 @@ function SingleAppRouter(appdir, runas, prefix, logDir, settings) {
       var indexType  = indexRmd ? 'rmd' : indexHtm ? 'html' : null;
       var indexPath = indexRmd || indexHtm;
 
-      if (app){
+      if (app || singleApp){
         appSpec.settings.mode = 'shiny';
       } else if(rmd){
         appSpec.settings.mode = 'rmd';


### PR DESCRIPTION
The one caveat here is that we don't gracefully handle the scenario in which an app.R file is found but the version of Shiny is not sufficiently updated to support the app.R model. If that occurs, shiny will produce an error about the UI not being found in `www/` nor `ui.R`

If we're ok with that, I'll merge this in and get it in Pro. If we want to explicitly check the version before trying to use this feature, then we'll need to bite off a larger chunk of work to make this a full-fledged third mode of operating Shiny so we can check the package versions within R like we do with Rmd.

Thoughts @jcheng5 / @wch ?
