### PR TITLE
our bin must be first to triumph over system-installed node

### DIFF
--- a/packaging/make-package.sh
+++ b/packaging/make-package.sh
@@ -55,7 +55,7 @@ DIR=`dirname $0`
 cd "$DIR"
 DIR=`pwd`
 # Add node, etc. to the path
-PATH=$PATH:$DIR/../bin/
+PATH=$DIR/../bin:$PATH
 mkdir -p build
 cd build
 "$CMAKE" -DCMAKE_INSTALL_PREFIX=/opt -DPYTHON="$PYTHON" ../..
@@ -67,7 +67,7 @@ pushd ../..
 ./bin/npm --python="${PYTHON}" rebuild
 
 # Need to rebuild ourselves since 'npm install' won't run gyp for us.
-./ext/node/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js --python="$PYTHON" rebuild
+./bin/node ./ext/node/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js --python="$PYTHON" rebuild
 
 popd
 # END: building in project root ----------------------------


### PR DESCRIPTION
also be explicit where possible about node

Keeps package building in-sync with our wiki build instructions, which were updated per #108.