### PR TITLE
v1.4.0 version bump

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,15 @@
+shiny-server 1.4.0
+--------------------------------------------------------------------------------
+* Bug fix: Load fonts over HTTPS.
+
+* Bug fix: Fix installer locale issue for Ubuntu 14.04.
+
+* Added support for Red Hat Enterprise Linux 7.
+
+* Bug fix: RH6 uses a statically linked Pandoc.
+
+* Support app_idle_timeout of 0.
+
 shiny-server 1.3.0
 --------------------------------------------------------------------------------
 * Added support for SUSE Linux Enterprise Server 11.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shiny-server",
   "preferGlobal": "true",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "RStudio <node@rstudio.com>",
   "description": "Application server for the Shiny web framework for R",
   "bin": "./lib/main.js",


### PR DESCRIPTION
Bump version and update NEWS for 1.4.0. Here are the differences from the 1.3.0 tag:
https://github.com/rstudio/shiny-server/compare/v1.3.0...master

After this is finalized, we still need to apply the v1.4.0 tag.