### PR TITLE
Add systemd script for Ubuntu 15.04

### DIFF
--- a/config/systemd/shiny-server.debian.service
+++ b/config/systemd/shiny-server.debian.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=ShinyServer
+
+[Service]
+TimeoutStartSec=10
+ExecStart=/bin/bash -c '/opt/shiny-server/bin/shiny-server --pidfile=/var/run/shiny-server.pid >> /var/log/shiny-server.log 2>&1'
+# Needed to give SS a chance to write out to the PID file.
+ExecStartPost=/bin/sleep 3
+PIDFile=/var/run/shiny-server.pid
+Type=simple
+
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStopPost=/bin/sleep 5
+RestartSec=1
+
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/debian-control/postinst.in
+++ b/packaging/debian-control/postinst.in
@@ -73,6 +73,10 @@ then
    systemctl stop shiny-server.service 2>/dev/null
    systemctl disable shiny-server.service 2>/dev/null
    cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/systemd/shiny-server.debian.service /etc/systemd/system/shiny-server.service
+   if ! grep -e "^Environment=\"LANG=" /etc/systemd/system/shiny-server.service; then
+      echo "Adding LANG to /etc/systemd/system/shiny-server.service, setting to $SS_LANG"
+      sed -i "11 a Environment=\"LANG=$SS_LANG\"" /etc/systemd/system/shiny-server.service
+   fi
    systemctl daemon-reload
    systemctl enable shiny-server.service
    systemctl start shiny-server.service

--- a/packaging/debian-control/postinst.in
+++ b/packaging/debian-control/postinst.in
@@ -67,7 +67,17 @@ else
 fi
 
 # add upstart profile or init.d script and start the server
-if test $LSB_RELEASE = "Ubuntu" && test -d /etc/init/
+INIT_SYSTEM=`cat /proc/1/comm`
+if test $INIT_SYSTEM = "systemd"
+then
+   systemctl stop shiny-server.service 2>/dev/null
+   systemctl disable shiny-server.service 2>/dev/null
+   cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/systemd/shiny-server.debian.service /etc/systemd/system/shiny-server.service
+   systemctl daemon-reload
+   systemctl enable shiny-server.service
+   systemctl start shiny-server.service
+   systemctl --no-pager status shiny-server.service
+elif test $LSB_RELEASE = "Ubuntu" && test -d /etc/init/
 then
    cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/upstart/shiny-server.conf /etc/init/
 

--- a/packaging/debian-control/prerm.in
+++ b/packaging/debian-control/prerm.in
@@ -3,7 +3,12 @@
 # errors shouldn't cause script to exit
 set +e
 
-sudo initctl stop shiny-server 2>/dev/null
+initctl stop shiny-server 2>/dev/null
+
+systemctl stop shiny-server.service 2>/dev/null
+systemctl disable shiny-server.service 2>/dev/null
+rm -rf /etc/systemd/system/shiny-server.service
+systemctl daemon-reload
 
 # clear error termination state
 set -e

--- a/vagrant/ubuntu15.04/.gitignore
+++ b/vagrant/ubuntu15.04/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/vagrant/ubuntu15.04/Vagrantfile
+++ b/vagrant/ubuntu15.04/Vagrantfile
@@ -24,7 +24,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/vivid64"
 
-  config.vm.host_name = "sso-ubuntu1504-latest"
+  # jcheng 2015-05-04: Hostname config appears not to work
+  #config.vm.host_name = "sso-ubuntu1504-latest"
   
   config.vm.provision "shell", path: "setup.sh"
 

--- a/vagrant/ubuntu15.04/Vagrantfile
+++ b/vagrant/ubuntu15.04/Vagrantfile
@@ -2,13 +2,13 @@
 # vi: set ft=ruby :
 
 ####################################
-#       Ubutntu 13.04 Build
+#       Ubutntu 15.04 Build
 #
 # Downloads and installs the latest
-# Ubuntu 13.04 build posted to S3 
-# from Jenkins in a Ubuntu13.04 VM.
+# Ubuntu 12.04 build posted to S3 
+# from Jenkins in a Ubuntu15.04 VM.
 #
-# IP: 10.0.0.70
+# IP: 10.0.0.88
 #
 ####################################
 
@@ -30,7 +30,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network :private_network, ip: "10.0.0.70"
+  config.vm.network :private_network, ip: "10.0.0.88"
   
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/vagrant/ubuntu15.04/Vagrantfile
+++ b/vagrant/ubuntu15.04/Vagrantfile
@@ -1,0 +1,65 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+####################################
+#       Ubutntu 13.04 Build
+#
+# Downloads and installs the latest
+# Ubuntu 13.04 build posted to S3 
+# from Jenkins in a Ubuntu13.04 VM.
+#
+# IP: 10.0.0.70
+#
+####################################
+
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/vivid64"
+
+  config.vm.host_name = "sso-ubuntu1504-latest"
+  
+  config.vm.provision "shell", path: "setup.sh"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network :private_network, ip: "10.0.0.70"
+  
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider :virtualbox do |vb|
+    # Don't boot with headless mode
+    # vb.gui = true
+  
+    # Use VBoxManage to customize the VM. For example to change memory:
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+  end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+end

--- a/vagrant/ubuntu15.04/setup.sh
+++ b/vagrant/ubuntu15.04/setup.sh
@@ -1,0 +1,19 @@
+echo "deb http://cran.rstudio.com/bin/linux/ubuntu raring/" >> /etc/apt/sources.list
+
+apt-get update
+
+# --force-yes to handle the un-verified deb
+apt-get install r-base-dev r-base -y --force-yes
+
+wget https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/VERSION -O "version.txt"
+VERSION=`cat version.txt`
+
+# Install the latest SSO build
+wget "https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/shiny-server-$VERSION-amd64.deb" -O ss-latest.deb
+
+apt-get install gdebi -y
+#gdebi -n ss-latest.deb
+
+R -e "install.packages('shiny', repos='http://cran.rstudio.com/')"
+
+cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/

--- a/vagrant/ubuntu15.04/setup.sh
+++ b/vagrant/ubuntu15.04/setup.sh
@@ -1,4 +1,4 @@
-echo "deb http://cran.rstudio.com/bin/linux/ubuntu raring/" >> /etc/apt/sources.list
+echo "deb http://cran.rstudio.com/bin/linux/ubuntu vivid/" >> /etc/apt/sources.list
 
 apt-get update
 
@@ -12,7 +12,7 @@ VERSION=`cat version.txt`
 wget "https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/shiny-server-$VERSION-amd64.deb" -O ss-latest.deb
 
 apt-get install gdebi -y
-#gdebi -n ss-latest.deb
+gdebi -n ss-latest.deb
 
 R -e "install.packages('shiny', repos='http://cran.rstudio.com/')"
 


### PR DESCRIPTION
The systemd script could probably be a lot simpler; we shouldn't
need a PIDFILE if we're not running in daemon mode. And I have a
feeling we shouldn't be writing into /var/log/shiny-server.log for
the main server, but rather to the systemd journal.

However, in the interest of getting a working build out to 15.04
users ASAP, and not having to retest Red Hat 7, we'll just take
our existing systemd file with minimal changes.