### PR TITLE
Copy instead of move Pandoc

### DIFF
--- a/packaging/rpm-script/postinst.sh.in
+++ b/packaging/rpm-script/postinst.sh.in
@@ -84,8 +84,8 @@ fi
 if [ -e /etc/SuSE-release ] || [ "$RH_VER" == "7" ]  || [ "$RH_VER" == "6" ]
 then
    # The default Pandoc binaries aren't compatible, overwrite with the static versions.
-   mv -f ${CMAKE_INSTALL_PREFIX}/shiny-server/ext/pandoc/static/pandoc ${CMAKE_INSTALL_PREFIX}/shiny-server/ext/pandoc/pandoc
-   mv -f ${CMAKE_INSTALL_PREFIX}/shiny-server/ext/pandoc/static/pandoc-citeproc ${CMAKE_INSTALL_PREFIX}/shiny-server/ext/pandoc/pandoc-citeproc
+   cp -f ${CMAKE_INSTALL_PREFIX}/shiny-server/ext/pandoc/static/pandoc ${CMAKE_INSTALL_PREFIX}/shiny-server/ext/pandoc/pandoc
+   cp -f ${CMAKE_INSTALL_PREFIX}/shiny-server/ext/pandoc/static/pandoc-citeproc ${CMAKE_INSTALL_PREFIX}/shiny-server/ext/pandoc/pandoc-citeproc
 fi
 
 # clear error termination state


### PR DESCRIPTION
By keeping the files that yum installs present, we make yum happier when
it goes to uninstall those files. So we'll copy instead of mv as a quick
fix.

Eventually, the right answer is actually to move this intelligence to
CMake and only ship with the appropriate version of pandoc. I had spent
a few hours on it many months ago and ended up deciding this was better
than wasting a day on it.