### PR TITLE
Install shiny section

### DIFF
--- a/latest/index.html
+++ b/latest/index.html
@@ -437,7 +437,7 @@ Choose from above solutions by number or cancel [1/2/c] (c): 2</code></pre>
 <p>You could alternatively use <code>curl</code> instead of <code>wget</code>, if <code>wget</code> is not available on your server.</p>
 <p>You'll also want to specify a secure default CRAN mirror in this same file. You can do that using the following code:</p>
 <pre><code>local({
-  r &lt;- getOptions(&quot;repos&quot;)
+  r &lt;- getOption(&quot;repos&quot;)
   r[&quot;CRAN&quot;] &lt;- &quot;https://cran.rstudio.com/&quot;
   options(repos=r)
 })</code></pre>


### PR DESCRIPTION
### Install Shiny
#### Setup the Server for Secure Package Installation

This section explains setting .Rprofile or Rprofile.site files, but the code:

```R
local({
  r <- getOptions("repos")
  r["CRAN"] <- "https://cran.rstudio.com/"
  options(repos=r)
})
```
causes errors when trying to install a package as `getOptions` isn't a function, `getOption` is correct (I think)

```R
local({
  r <- getOption("repos")
  r["CRAN"] <- "https://cran.rstudio.com/"
  options(repos=r)
})
```