### PR TITLE
Explicitly cd into the appropriate directory.

### DIFF
--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -159,7 +159,7 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
         '--',
         appSpec.runAs,
         '-c',
-        bash.escape(rprog) + " --no-save --slave -f " + bash.escape(scriptPath)
+        'cd ' + bash.escape(appSpec.appDir) + ' && ' + bash.escape(rprog) + " --no-save --slave -f " + bash.escape(scriptPath)
       ];
       
       if (process.platform === 'linux') {


### PR DESCRIPTION
On (at least) RHEL7, su's -p switch is clobbered by the --login switch, meaning that the current directory is no longer maintained across the su call. Instead, the user's home directory will be the dir of the executed command. For us, that means the app is running out of the wrong directory and will not properly respect things like an .RProfile in the app dir.

Fixes #143

@fereshtehRS it will be worthwhile to test this across distros. I haven't seen any problems with this syntax where I've tested, but it is a deviation in syntax from how we've spawned R in the past.