### PR TITLE
Don't require root write access to log directories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ install(DIRECTORY assets
                   manual.test
                   node_modules
                   R
+                  scripts
                   templates
                   test
                   tools

--- a/R/SockJSAdapter.R
+++ b/R/SockJSAdapter.R
@@ -22,8 +22,16 @@ local({
   SHINY_SERVER_VERSION=input[5],
   WORKER_ID=input[6],
   SHINY_MODE=input[7],
-  RSTUDIO_PANDOC=input[8])
+  RSTUDIO_PANDOC=input[8],
+  LOG_FILE=input[9])
   close(fd)
+
+  if (!identical(Sys.getenv('LOG_FILE'), "")){
+    # Redirect stderr to the given path.
+    message("Redirecting to ", Sys.getenv("LOG_FILE"))
+    errFile <- file(Sys.getenv('LOG_FILE'), "a")
+    sink(errFile, type="message")
+  }
 
   MIN_R_VERSION <- "2.15.1"
   MIN_SHINY_VERSION <- "0.7.0"

--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -189,3 +189,9 @@ preserve_logs {
   maxcount 1;
 }
 
+log_as_user {
+  desc "By default, the log files for R processes are created and managed by the user running the server centrally (often root). In the typical scenario in which the logs are stored in a server-wide directory, this is desirable as only root user may have write access to such a directory. In other cases, such as using `user_dirs` on a system in which the users' home directories are on an NFS mount which uses `root_squash`, creating log files as root may be a problem. In those scenarios, this option can be set to true to have the log files created by the users running the associated processes.";
+  param Boolean [enabled] "Whether or not the log files should be managed by the owner of the process to which they belong." false;
+  at $ server location;
+  maxcount 1;
+}

--- a/lib/router/config-router.js
+++ b/lib/router/config-router.js
@@ -474,6 +474,9 @@ function createLocation(locNode) {
   if (gaid)
     settings.gaTrackingId = gaid;
 
+  var logAsUser = locNode.getValues('log_as_user').enabled;
+  settings.logAsUser = logAsUser;
+
   // Add the templateDir to the AppSpec, if we have one.
   var templateDir = locNode.getValues('template_dir').dir;
   if (templateDir){

--- a/lib/router/directory-router.js
+++ b/lib/router/directory-router.js
@@ -125,9 +125,11 @@ function DirectoryRouter(root, runas, dirIndex, prefix, logdir, settings,
           settings.mode = subpath.type;
 
           // Valid request in an application path
-          return new AppSpec(appDir,
+          var as = new AppSpec(appDir,
             self.$runas, prefix + subpath.res.rawPath, self.$logdir,
               settings);
+          as.logAsUser = settings.logAsUser;
+          return as;
         }
       } else {
         // Not in Shiny app directory; serve statically

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -224,6 +224,8 @@ function SingleAppRouter(appdir, runas, prefix, logDir, settings) {
     var appSpec = new AppSpec(self.$appdir, self.$runas, self.$prefix, 
       self.$logDir, settings);
 
+    appSpec.logAsUser = settings.logAsUser;
+
     return Q.nfcall(fs.readdir, appSpec.appDir)
     .then(function(files){ 
       var app = _.find(files, function(entry) {

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -224,8 +224,6 @@ function SingleAppRouter(appdir, runas, prefix, logDir, settings) {
     var appSpec = new AppSpec(self.$appdir, self.$runas, self.$prefix, 
       self.$logDir, settings);
 
-    appSpec.logAsUser = settings.logAsUser;
-
     return Q.nfcall(fs.readdir, appSpec.appDir)
     .then(function(files){ 
       var app = _.find(files, function(entry) {

--- a/lib/router/user-dirs-router.js
+++ b/lib/router/user-dirs-router.js
@@ -75,22 +75,6 @@ function UserDirsRouter(prefix, groups, settings, runas, dirIndex) {
 
     var dir = path.join(pw.home, 'ShinyApps');
     var logDir = path.join(pw.home, 'ShinyApps', 'log');
-    try {
-      fs.mkdirSync(logDir, '755'); //FIXME: do as user
-      fs.chownSync(logDir, pw.uid, pw.gid);
-    } catch (ex) {
-      try {
-        var stat = fs.statSync(logDir);
-        if (!stat.isDirectory()) {
-          logger.error('Log directory existed, was a file: ' + logDir);
-          logDir = null;
-        }
-      } catch (ex2) {
-        logger.error('Log directory creation failed: ' + ex2.message);
-        logDir = null;
-      }
-    }
-
     var settings = JSON.parse(JSON.stringify(this.$settings));
 
     var dirRouter = new DirectoryRouter(dir, runas, this.$dirIndex, prefix, 

--- a/lib/router/user-dirs-router.js
+++ b/lib/router/user-dirs-router.js
@@ -76,7 +76,7 @@ function UserDirsRouter(prefix, groups, settings, runas, dirIndex) {
     var dir = path.join(pw.home, 'ShinyApps');
     var logDir = path.join(pw.home, 'ShinyApps', 'log');
     try {
-      fs.mkdirSync(logDir, '755');
+      fs.mkdirSync(logDir, '755'); //FIXME: do as user
       fs.chownSync(logDir, pw.uid, pw.gid);
     } catch (ex) {
       try {

--- a/lib/scheduler/scheduler.js
+++ b/lib/scheduler/scheduler.js
@@ -205,7 +205,9 @@ function connectEndpoint_p(endpoint, timeout, shouldContinue) {
               });
             } else {
               fs.unlink(logFilePath, function(err){
-                logger.warn('Failed to delete log file ' + logFilePath + ': ' + err.message);
+                if (err){
+                  logger.warn('Failed to delete log file ' + logFilePath + ': ' + err.message);
+                }
               });
             }
 

--- a/lib/scheduler/scheduler.js
+++ b/lib/scheduler/scheduler.js
@@ -10,6 +10,7 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
+var child_process = require('child_process');
 var crypto = require('crypto');
 var fs = require('fs');
 var os = require('os');
@@ -26,6 +27,7 @@ require('../core/log');
 var fsutil = require('../core/fsutil');
 var AppWorkerHandle = require('../worker/app-worker-handle');
 var app_worker = require('../worker/app-worker');
+var posix = require('../../build/Release/posix');
 
 /**
  * @param appSpec the appSpec associated
@@ -160,12 +162,16 @@ function connectEndpoint_p(endpoint, timeout, shouldContinue) {
     .then(function(endpoint) {
 
       logFilePath = self.getLogFilePath(appSpec, endpoint);
+      if (!appSpec.runAs)
+        throw new Error("No user specified");
+
+      var pw = posix.getpwnam(appSpec.runAs);
 
       var deleteLogFileOnExit = false;
       logger.trace('Launching ' + appSpec.appDir + ' as ' + appSpec.runAs +
         ' with on ' + endpoint.toString());
       var workerPromise = app_worker.launchWorker_p(
-        appSpec, endpoint, logFilePath, workerId);
+        appSpec, pw, endpoint, logFilePath, workerId);
       
       var exitPromise = workerPromise.invoke('getExit_p');
       exitPromise
@@ -188,10 +194,21 @@ function connectEndpoint_p(endpoint, timeout, shouldContinue) {
           if (!appSpec.settings || !appSpec.settings.appDefaults || 
               !appSpec.settings.appDefaults.preserveLogs){
             logger.trace('Normal exit, deleting log file ' + logFilePath);
-            fs.unlink(logFilePath, function(err) {
-              if (err)
+
+            if(appSpec.logAsUser){
+              var rm = child_process.spawn("rm", [logFilePath], 
+                {uid: pw.uid, gid: pw.gid});
+              rm.on('close', function (code) {
+                if (code != 0){
+                  logger.warn('Failed to delete log file ' + logFilePath + ': exit code ' + code);
+                }
+              });
+            } else {
+              fs.unlink(logFilePath, function(err){
                 logger.warn('Failed to delete log file ' + logFilePath + ': ' + err.message);
-            });
+              });
+            }
+
           } else {
             logger.trace('Declining to delete log file of successful execution: ' + logFilePath);
           }

--- a/lib/worker/app-spec.js
+++ b/lib/worker/app-spec.js
@@ -19,6 +19,7 @@ var AppSpec = function(appDir, runAs, prefix, logDir, settings) {
   this.prefix = prefix;
   this.logDir = logDir;
   this.settings = settings;
+  this.logAsUser = settings.logAsUser;
 };
 module.exports = AppSpec;
 

--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -76,29 +76,38 @@ function launchWorker_p(appSpec, endpoint, logFilePath, workerId) {
       err.code = 'ENOTFOUND';
       throw err;
     }
-    
-    // Open the log file asynchronously, then create the worker
-    return Q.nfcall(fs.open, logFilePath, 'a', 0660).then(function(logStream) {
-      fs.fchown(logStream, pw.uid, pw.gid, function(err) {
-        if (err)
-          logger.error('Error attempting to change permissions on log file at ' + logFilePath + ': ' + err.message);
-      });
-
-      // Create the worker; when it exits (or fails to start), close
-      // the logStream.
-      var worker = new AppWorker(appSpec, endpoint, logStream, workerId, 
-        pw.home);
-      worker.getExit_p()
-      .fin(function() {
-        fs.close(logStream, function(err) {
+   
+    appSpec.logAsUser = true; //FIXME
+    if (!appSpec.logAsUser){
+      // Manage the log file as root
+      // Open the log file asynchronously, then create the worker
+      return Q.nfcall(fs.open, logFilePath, 'a', 0660).then(function(logStream) {
+        fs.fchown(logStream, pw.uid, pw.gid, function(err) {
           if (err)
-            logger.error("Couldn't close logStream: " + err.message);
+            logger.error('Error attempting to change permissions on log file at ' + logFilePath + ': ' + err.message);
         });
-      })
-      .eat();
 
-      return worker;
-    });
+        // Create the worker; when it exits (or fails to start), close
+        // the logStream.
+        var worker = new AppWorker(appSpec, endpoint, logStream, workerId, 
+          pw.home);
+        worker.getExit_p()
+        .fin(function() {
+          fs.close(logStream, function(err) {
+            if (err)
+              logger.error("Couldn't close logStream: " + err.message);
+          });
+        })
+        .eat();
+
+        return worker;
+      });
+    } else {
+      // Have R do the logging
+      var worker = new AppWorker(appSpec, endpoint, logFilePath, workerId, 
+        pw.home);
+      return Q(worker);
+    }
   });
 };
 exports.launchWorker_p = launchWorker_p;
@@ -119,7 +128,9 @@ exports.runWorker_p = runWorker_p;
  * @param {AppSpec} appSpec - Contains the basic details about the app to
  *   launch
  * @param {String} endpoint - The transport endpoint the app should listen on
- * @param {Stream} logStream - The stream to dump stderr to.
+ * @param {Stream} logStream - The stream to dump stderr to, or the path to 
+ *   the file where the logging should happen. If just the path, pass it in
+ *   to the R proc to have R handle the logging itself.
  */
 var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
   this.$dfEnded = Q.defer();
@@ -174,6 +185,14 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
       args = ['--no-save', '--slave', '-f', scriptPath];
     }
 
+    // The file where R should send stderr, or empty if it should leave it alone.
+    var logFile = '';
+    if (_.isString(logStream)){
+      logFile = logStream;
+      logStream = 'ignore'; // Tell the child process to drop stderr
+      logger.trace('Asking R to send stderr to ' + logFile);
+    }
+
     var self = this;
 
     Q.nfcall(fs.stat, appSpec.appDir)
@@ -183,7 +202,7 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
           appSpec.appDir);
       }
       self.$proc = child_process.spawn(executable, args, {
-        stdio: ['pipe', 'pipe', logStream],
+        stdio: ['pipe', 'pipe', 'pipe'], //FIXME //logStream],
         cwd: appSpec.appDir,
         env: map.compact({
           'HOME' : home,
@@ -209,9 +228,14 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
         SHINY_SERVER_VERSION + '\n' + 
         workerId + '\n' + 
         mode + '\n' + 
-        paths.projectFile('ext/pandoc') + '\n'
+        paths.projectFile('ext/pandoc') + '\n' + 
+        logFile + '\n'
       );
+      self.$proc.stderr.pipe(split()).on('data', function(line){
+	console.log("ERR: " + line);
+      });
       self.$proc.stdout.pipe(split()).on('data', function(line){
+console.log("OUT: " + line);
         var match = null;
         if (line.match(/^Starting Shiny with process ID: '(\d+)'$/)){
           var pid = parseInt(

--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -42,6 +42,30 @@ function exists_p(path) {
   return defer.promise;
 }
 
+function spawnUserLog_p(pw, logDir, appSpec, endpoint, logFilePath, workerId) {
+  var prom = Q.defer();
+  var logDir = path.join(pw.home, 'ShinyApps', 'log');
+
+  // Ensure that the log directory exists.
+  var rm = child_process.spawn(paths.projectFile('scripts/mkdir.sh'), [logDir, pw.uid, pw.gid], 
+    {uid: pw.uid, gid: pw.gid});
+  rm.on('close', function (code) {
+    if (code != 0){
+      var err = "Failed to create log directory: " + logDir +", " + pw.uid + ":" + pw.gid;
+      logger.error(err);
+      prom.reject(err);
+    }
+
+    // Have R do the logging
+    var worker = new AppWorker(appSpec, endpoint, logFilePath, workerId, 
+      pw.home);
+    prom.resolve(worker);
+  });
+
+  return prom.promise;
+}
+
+
 /**
  * Begins launching the worker; returns a promise that resolves when
  * the worker is constructed (doesn't necessarily mean the process has
@@ -115,26 +139,7 @@ function launchWorker_p(appSpec, pw, endpoint, logFilePath, workerId) {
         return worker;
       });
     } else {
-      var prom = Q.defer();
-      var logDir = path.join(pw.home, 'ShinyApps', 'log');
-
-      // Ensure that the log directory exists.
-      var rm = child_process.spawn(paths.projectFile('scripts/mkdir.sh'), [logDir, pw.uid, pw.gid], 
-        {uid: pw.uid, gid: pw.gid});
-      rm.on('close', function (code) {
-        if (code != 0){
-          var err = "Failed to create log directory: " + logDir +", " + pw.uid + ":" + pw.gid;
-          logger.error(err);
-	  prom.reject(err);
-        }
-
-        // Have R do the logging
-        var worker = new AppWorker(appSpec, endpoint, logFilePath, workerId, 
-          pw.home);
-        prom.resolve(worker);
-      });
-
-      return prom.promise;
+      return spawnUserLog_p(pw, logDir, appSpec, endpoint, logFilePath, workerId);
     }
   });
 };

--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -66,7 +66,7 @@ function launchWorker_p(appSpec, pw, endpoint, logFilePath, workerId) {
     return Q.reject(new Error("No app directory specified"));
 
 
-  return exists_p(appSpec.appDir).then(function(exists) {
+  return exists_p(appSpec.appDir).then(function(exists) { // TODO: does this need to be as user?
     if (!exists) {
       var err = new Error("App dir " + appSpec.appDir + " does not exist");
       err.code = 'ENOTFOUND';
@@ -74,6 +74,23 @@ function launchWorker_p(appSpec, pw, endpoint, logFilePath, workerId) {
     }
    
     if (!appSpec.logAsUser){
+      // Ensure that the log directory exists.
+      try {
+        fs.mkdirSync(logDir, '755');
+        fs.chownSync(logDir, pw.uid, pw.gid);
+      } catch (ex) {
+        try {
+          var stat = fs.statSync(logDir);
+          if (!stat.isDirectory()) {
+            logger.error('Log directory existed, was a file: ' + logDir);
+            logDir = null;
+          }
+        } catch (ex2) {
+          logger.error('Log directory creation failed: ' + ex2.message);
+          logDir = null;
+        }
+      }
+
       // Manage the log file as root
       // Open the log file asynchronously, then create the worker
       return Q.nfcall(fs.open, logFilePath, 'a', 0660).then(function(logStream) {
@@ -98,10 +115,26 @@ function launchWorker_p(appSpec, pw, endpoint, logFilePath, workerId) {
         return worker;
       });
     } else {
-      // Have R do the logging
-      var worker = new AppWorker(appSpec, endpoint, logFilePath, workerId, 
-        pw.home);
-      return Q(worker);
+      var prom = Q.defer();
+      var logDir = path.join(pw.home, 'ShinyApps', 'log');
+
+      // Ensure that the log directory exists.
+      var rm = child_process.spawn(paths.projectFile('scripts/mkdir.sh'), [logDir, pw.uid, pw.gid], 
+        {uid: pw.uid, gid: pw.gid});
+      rm.on('close', function (code) {
+        if (code != 0){
+          var err = "Failed to create log directory: " + logDir +", " + pw.uid + ":" + pw.gid;
+          logger.error(err);
+	  prom.reject(err);
+        }
+
+        // Have R do the logging
+        var worker = new AppWorker(appSpec, endpoint, logFilePath, workerId, 
+          pw.home);
+        prom.resolve(worker);
+      });
+
+      return prom.promise;
     }
   });
 };

--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -29,7 +29,6 @@ var _ = require('underscore');
 var map = require('../core/map');
 var paths = require('../core/paths');
 var permissions = require('../core/permissions');
-var posix = require('../../build/Release/posix');
 var split = require('split');
 
 var rprog = process.env.R || 'R';
@@ -50,16 +49,13 @@ function exists_p(path) {
  *
  * @param {AppSpec} appSpec - Contains the basic details about the app to
  *   launch
+ * @param pw - the user info, a result of `posix.getpwnam()`
  * @param {Endpoint} endpoint - The endpoint that the Shiny app should
  *   listen on.
  * @param {String} logFilePath - The file path to write stderr to.
  */
-function launchWorker_p(appSpec, endpoint, logFilePath, workerId) {
-  if (!appSpec.runAs)
-    return Q.reject(new Error("No user specified"));
-
-  var pw = posix.getpwnam(appSpec.runAs);
-  if (!pw)
+function launchWorker_p(appSpec, pw, endpoint, logFilePath, workerId) {
+   if (!pw)
     return Q.reject(new Error("User " + appSpec.runAs + " does not exist"));
 
   if (!pw.home)
@@ -77,7 +73,6 @@ function launchWorker_p(appSpec, endpoint, logFilePath, workerId) {
       throw err;
     }
    
-    appSpec.logAsUser = true; //FIXME
     if (!appSpec.logAsUser){
       // Manage the log file as root
       // Open the log file asynchronously, then create the worker
@@ -202,7 +197,7 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
           appSpec.appDir);
       }
       self.$proc = child_process.spawn(executable, args, {
-        stdio: ['pipe', 'pipe', 'pipe'], //FIXME //logStream],
+        stdio: ['pipe', 'pipe', logStream],
         cwd: appSpec.appDir,
         env: map.compact({
           'HOME' : home,
@@ -231,11 +226,7 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
         paths.projectFile('ext/pandoc') + '\n' + 
         logFile + '\n'
       );
-      self.$proc.stderr.pipe(split()).on('data', function(line){
-	console.log("ERR: " + line);
-      });
       self.$proc.stdout.pipe(split()).on('data', function(line){
-console.log("OUT: " + line);
         var match = null;
         if (line.match(/^Starting Shiny with process ID: '(\d+)'$/)){
           var pid = parseInt(

--- a/scripts/mkdir.sh
+++ b/scripts/mkdir.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e 
+
+if [ $# -ne "3" ]; then
+  echo "You must provide two arguments: the name of the directory, the user name, and the group name"
+  exit 1;
+fi
+
+# Create a directory and check its ownership
+echo "Creating directory $1 if it doesn't exist."
+[ -d "$1" ] || mkdir "$1"
+
+echo "Chmodding to 755"
+chmod 755 "$1"
+
+echo "Chowning directory $1 to $2:$3"
+chown "$2":"$3" "$1"
+
+if [ ! -d "$1" ]; then
+  echo "The given path is not a directory."
+  exit 1;
+fi

--- a/vagrant/nfs/README.md
+++ b/vagrant/nfs/README.md
@@ -1,0 +1,15 @@
+
+
+Spin up the NFS server first:
+
+```
+vagrant up nfs
+```
+
+Then you can bring up the Shiny Server machine:
+
+```
+vagrant up sso
+```
+
+At this point, you should have a Shiny Server instance which mounts the directory `/home/shiny` over NFS with `root_squash` which can be used to test user_dirs over NFS with root_squash.

--- a/vagrant/nfs/Vagrantfile
+++ b/vagrant/nfs/Vagrantfile
@@ -1,0 +1,29 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  # define primary development box
+  config.vm.define "sso", primary: true do |p|
+    p.vm.box = "ubuntu/trusty64"
+    p.vm.network "private_network", ip: "192.168.42.101"
+    p.vm.network "forwarded_port", guest: 3838, host: 3838, auto_correct: true
+    p.vm.provision :shell, path: "provision-sso.sh"
+  end
+
+  config.vm.define "nfs", autostart: false do |b|
+    b.vm.box = "ubuntu/trusty64"
+    b.vm.network "private_network", ip: "192.168.42.102"
+    b.vm.provision :shell, path: "provision-nfs.sh"
+  end
+
+  # give machine liberal cpu & core resources for virtualbox (adjust to taste)
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "2048"
+    vb.cpus = "2"
+  end
+
+  config.vm.synced_folder "../../", "/shiny-server"
+  config.vm.synced_folder "../../", "/home/vagrant/shiny-server"
+
+  config.vm.provision :shell, path: "bootstrap-debian.sh"
+end

--- a/vagrant/nfs/bootstrap-debian.sh
+++ b/vagrant/nfs/bootstrap-debian.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# add repo for R 
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+echo "deb https://cran.rstudio.com/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list
+
+# bring apt database up to date with R packages
+apt-get update
+
+# install R
+apt-get install -y --force-yes r-base r-base-dev
+
+# install minimal packages needed to run bootstrap scripts
+apt-get install -y unzip
+apt-get install -y git
+apt-get install -y g++
+apt-get install -y wget
+
+# install packages needed to build and run devtools
+apt-get install -y libssh2-1-dev
+apt-get install -y curl 
+apt-get install -y libcurl4-openssl-dev
+
+

--- a/vagrant/nfs/provision-nfs.sh
+++ b/vagrant/nfs/provision-nfs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# install NFS server and export user home directories
+apt-get install -y nfs-kernel-server
+echo "/home/shiny   *(rw,sync,root_squash)" >> /etc/exports
+service nfs-kernel-server start
+
+# Create Shiny user
+useradd -r -m shiny
+mkdir /home/shiny/ShinyApps/
+chown -R shiny:shiny /home/shiny
+chmod 700 -R /home/shiny
+
+# Install apps in Shiny user's personal dir
+git clone https://github.com/rstudio/shiny.git
+cp -R shiny/inst/examples/* /home/shiny/ShinyApps/
+

--- a/vagrant/nfs/provision-sso.sh
+++ b/vagrant/nfs/provision-sso.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# install packages needed for development environment
+apt-get install -y vim
+
+# connect to NFS server already running on the primary machine
+apt-get install -y nfs-common
+mkdir -p /home/shiny
+echo "192.168.42.102:/home /home/shiny/ nfs rsize=8192,wsize=8192,timeo=14,intr" >> /etc/fstab
+mount -a 
+
+wget https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/VERSION -O "version.txt"
+VERSION=`cat version.txt`                                                          
+                                                                                   
+# Install the latest SSO build                                                     
+wget "https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/shiny-server-$VERSION-amd64.deb" -O ss-latest.deb
+                                                                                   
+apt-get install gdebi -y                                                           
+gdebi -n ss-latest.deb                                                             
+                                                                                   
+# R is too old for CRAN's latest Rcpp                                              
+wget http://cran.r-project.org/src/contrib/Archive/Rcpp/Rcpp_0.10.5.tar.gz -O Rcpp_0.10.5.tar.gz
+R CMD INSTALL Rcpp_0.10.5.tar.gz                                                   
+                                                                                   
+R -e "install.packages('shiny', repos='http://cran.rstudio.com/')"                 
+                                                                                   
+cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/
+
+cp /shiny-server/vagrant/nfs/shiny-server.conf /etc/shiny-server/shiny-server.conf
+restart shiny-server

--- a/vagrant/nfs/shiny-server.conf
+++ b/vagrant/nfs/shiny-server.conf
@@ -1,0 +1,18 @@
+# Instruct Shiny Server to run applications as the user "shiny"
+run_as shiny;
+
+# Define a server that listens on port 3838
+server {
+  listen 3838;
+
+  # Define a location at the base URL
+  location / {
+
+    # Host the directory of Shiny Apps stored in this directory
+    user_apps;
+
+    # When a user visits the base URL rather than a particular application,
+    # an index of the applications available in this directory will be shown.
+    directory_index on;
+  }
+}


### PR DESCRIPTION
I think we're at a stopping point, albeit a disappointing one.

This PR adds a config option which removes the requirement for root to have write access for `~/ShinyApps/log` when spawning R processes on behalf of another user. This requirements presents problems for e.g. `root_squash`'d NFS mounts.

Unfortunately, there's still quite a bit of complicated code that requires read access to the user's ShinyApps dir so that we can find where the application is that we're supposed to be hosting and what mode we should be in. This is going to be complicated to replace with code that runs as another user.

The ultimate approach to fixing this may be to write a wrapper around the `fs` module that does at least some of that functionality with `uid` and `gid` parameters, which replicates the native behavior by wrapping shell commands that get spawned as the appropriate user. That would probably be the best way to avoid polluting the code, but would be a decent amount of effort.

But I believe this PR will solve the root_squash issues given that the user's ShinyApps directories are root-readable (the default in Ubuntu, but likely nowhere else).

(Touches #64 / #101.)

