### PR TITLE
Ensure logdir var exists.

### DIFF
--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -44,7 +44,7 @@ function exists_p(path) {
 
 function spawnUserLog_p(pw, appSpec, endpoint, logFilePath, workerId) {
   var prom = Q.defer();
-  var logDir = path.join(pw.home, 'ShinyApps', 'log');
+  var logDir = path.dirname(logFilePath); 
 
   // Ensure that the log directory exists.
   var rm = child_process.spawn(paths.projectFile('scripts/mkdir.sh'), [logDir, pw.uid, pw.gid], 
@@ -98,6 +98,7 @@ function launchWorker_p(appSpec, pw, endpoint, logFilePath, workerId) {
     }
    
     if (!appSpec.logAsUser){
+      var logDir = path.dirname(logFilePath);
       // Ensure that the log directory exists.
       try {
         fs.mkdirSync(logDir, '755');


### PR DESCRIPTION
 - Fixes bug in which log directory wouldn't be created in non-log_as_user mode
 - Doesn't presume user_dirs log locations when using log_as_user.