### PR TITLE
Add reconnect capabilities

### DIFF
--- a/R/SockJSAdapter.R
+++ b/R/SockJSAdapter.R
@@ -132,6 +132,7 @@ local({
    inject <- paste(
       tags$script(src='__assets__/sockjs-0.3.min.js'),
       tags$script(src='__assets__/shiny-server.js'),
+      tags$link(rel='stylesheet', type='text/css', href='__assets__/shiny-server.css'),
       gaTrackingCode,
       HTML("</head>"),
       sep="\n"

--- a/assets/shiny-server.css
+++ b/assets/shiny-server.css
@@ -1,4 +1,4 @@
-body.reconnecting {
+body.ss-reconnecting {
   background: none;
   opacity: 1;
 }

--- a/assets/shiny-server.css
+++ b/assets/shiny-server.css
@@ -1,0 +1,42 @@
+body.reconnecting {
+  background: none;
+  opacity: 1;
+}
+
+body.disconnected {
+  background: none;
+  opacity: 1;
+}
+
+#ss-connect-dialog {
+  opacity: 1 !important;
+  padding: .5em 1em 1em 1em;
+  background-color: #FFF;
+  position: absolute;
+  top: 0;
+  left: 30%;
+  right: 30%;
+  z-index: 99999;
+}
+
+.ss-dialog-button {
+  float: right;
+}
+
+.ss-dialog-text {
+}
+
+#ss-gray-out {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #999;
+  opacity: 0.7;
+  z-index: 99998;
+}
+
+#ss-clearfix {
+  clear: both;
+}

--- a/assets/shiny-server.css
+++ b/assets/shiny-server.css
@@ -12,7 +12,7 @@ body.disconnected {
   opacity: 1 !important;
   padding: .5em 1em 1em 1em;
   background-color: #FFF;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 30%;
   right: 30%;
@@ -27,14 +27,15 @@ body.disconnected {
 }
 
 #ss-gray-out {
-  position: absolute;
+  position: fixed;
   top: 0;
-  bottom: 0;
   left: 0;
+  bottom: 0;
   right: 0;
   background-color: #999;
   opacity: 0.7;
   z-index: 99998;
+  overflow: hidden;
 }
 
 #ss-clearfix {

--- a/assets/shiny-server.js
+++ b/assets/shiny-server.js
@@ -449,51 +449,51 @@
     };
 
     // Open a connection now.
-		this._openConnection();
+    this._openConnection();
 
-		this._parseMultiplexData = function(msg) {
-			try {
-				var m = /^(\d+)\|(m|o|c|r)\|([\s\S]*)$/m.exec(msg);
-				if (!m)
-					return null;
-				msg = {
-					id: m[1],
-					method: m[2],
-					payload: m[3]
-				};
+    this._parseMultiplexData = function(msg) {
+      try {
+        var m = /^(\d+)\|(m|o|c|r)\|([\s\S]*)$/m.exec(msg);
+        if (!m)
+          return null;
+        msg = {
+          id: m[1],
+          method: m[2],
+          payload: m[3]
+        };
 
-				switch (msg.method) {
-					case 'm':
-						break;
-					case 'o':
-						if (msg.payload.length === 0)
-							return null;
-						break;
-					case 'c':
-						try {
-							msg.payload = JSON.parse(msg.payload);
-						} catch(e) {
-							return null;
-						}
-						break;
+        switch (msg.method) {
+          case 'm':
+            break;
+          case 'o':
+            if (msg.payload.length === 0)
+              return null;
+            break;
+          case 'c':
+            try {
+              msg.payload = JSON.parse(msg.payload);
+            } catch(e) {
+              return null;
+            }
+            break;
           case 'r':
             self._disconnected = true;
             if (msg.payload.length > 0){
               alert(msg.payload);
             }
             break;
-					default:
-						return null;
-				}
+          default:
+            return null;
+        }
 
-				return msg;
+        return msg;
 
-			} catch(e) {
-				if (console && console.log)
-					console.log('Error parsing multiplex data: ' + e);
-				return null;
-			}
-		};
+      } catch(e) {
+        if (console && console.log)
+          console.log('Error parsing multiplex data: ' + e);
+        return null;
+      }
+    };
 
   }
   MultiplexClient.prototype.open = function(url) {

--- a/assets/shiny-server.js
+++ b/assets/shiny-server.js
@@ -1,13 +1,13 @@
 
 (function( $ ) {
   function generateId(size){
-		var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-		var id = '';
-		for (var i=0; i < size; i++) {
-			var rnum = Math.floor(Math.random() * chars.length);
-			id += chars.substring(rnum,rnum+1);
-		}
-		return id;
+    var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    var id = '';
+    for (var i=0; i < size; i++) {
+      var rnum = Math.floor(Math.random() * chars.length);
+      id += chars.substring(rnum,rnum+1);
+    }
+    return id;
   }
   var robustId = generateId(18);
 
@@ -36,7 +36,7 @@
           // This is why we append `__sockjs__` to each path before comparing.
           function getRelativePath(from, to, includeLast) {
 
-						// The last element would otherwise get trimmed off, if you want it,
+            // The last element would otherwise get trimmed off, if you want it,
             // add some garbage to the end that can be trimmed.
             if (includeLast){
               to += '/a';
@@ -134,7 +134,7 @@
             });
           }
         } 
-  
+
         if (!whitelist){
           whitelist = availableOptions;
         }
@@ -260,11 +260,11 @@
   // zero channels, open a channel, close that channel, and then open
   // another channel.
   function MultiplexClient(sockjsUrl, whitelist) {
-		// The URL target for our SockJS connection(s)
-		this._sockjsUrl = sockjsUrl;
-		// The whitelisted SockJS protocols
-		this._whitelist = whitelist;
-		// Placeholder for our SockJS connection, once we open it.
+    // The URL target for our SockJS connection(s)
+    this._sockjsUrl = sockjsUrl;
+    // The whitelisted SockJS protocols
+    this._whitelist = whitelist;
+    // Placeholder for our SockJS connection, once we open it.
     this._conn = null;
     // A table of all active channels.
     // Key: id, value: MultiplexClientChannel
@@ -317,7 +317,7 @@
           debug("NOT opening channel " + channel.id);
         }
       }
-      
+
       // Send any buffered messages.
       var msg;
       while ((msg = self._buffer.shift())){
@@ -543,7 +543,7 @@
     this.readyState = 1;
 
     //var relURL = getRelativePath(parentURL, this.url)
-    
+
     this._owner.send(formatOpenEvent(this.id, this.url));
     this.onopen();
   };

--- a/assets/shiny-server.js
+++ b/assets/shiny-server.js
@@ -313,7 +313,7 @@ window.conn = self._conn;
       
       // Send any buffered messages.
       var msg;
-      while ((msg = self._buffer.pop())){
+      while ((msg = self._buffer.shift())){
         self._conn.send(msg);
       }
     };

--- a/assets/shiny-server.js
+++ b/assets/shiny-server.js
@@ -148,7 +148,7 @@
         // Has the side-effect of defining values for both "networkSelector"
         // and "networkOptions".
         function buildNetworkSelector() {
-          networkSelector = $('<div style="top: 50%; left: 50%; position: absolute;">' + 
+          networkSelector = $('<div style="top: 50%; left: 50%; position: absolute; z-index: 99999;">' + 
                            '<div style="position: relative; width: 300px; margin-left: -150px; padding: .5em 1em 0 1em; height: 400px; margin-top: -190px; background-color: #FAFAFA; border: 1px solid #CCC; font.size: 1.2em;">'+
                            '<h3>Select Network Methods</h3>' +
                            '<div id="ss-net-opts"></div>' + 

--- a/assets/shiny-server.js
+++ b/assets/shiny-server.js
@@ -371,12 +371,16 @@ window.conn = self._conn;
       log("Connection closed. Info: " + JSON.stringify(e));
       debug("SockJS connection closed");
 
-      //TODO: if this feature is enabled
-      //FIXME: this should be only on unclean closes, and ones not initiated by 
+      // If the server intentionally closed the connection, don't attempt to come back.
+      if (e && e.wasClean === true){
+        self._disconnected = true;
+      }
+
       // the server intentionally.
       self.startDisconnect();
       return;
 
+      //TODO: if this feature isn't enabled
       self._doClose();
     };
 

--- a/assets/shiny-server.js
+++ b/assets/shiny-server.js
@@ -289,6 +289,8 @@
     // True when the re/disconnect dialog is visible
     this._disconnectDialog = false;
 
+    this._autoReconnect = {{{reconnect}}};
+
     var self = this;
 
     this.send = function(msg){
@@ -385,12 +387,13 @@
         self._disconnected = true;
       }
 
-      // the server intentionally.
-      self.startDisconnect();
-      return;
-
-      //TODO: if this feature isn't enabled
-      self._doClose();
+      if (self._autoReconnect) {
+        // the server intentionally.
+        self.startDisconnect();
+      } else {
+        self._doClose();
+        $('<div id="ss-gray-out"></div>').appendTo('body');
+      }
     };
 
     this._doClose = function(){

--- a/assets/shiny-server.js
+++ b/assets/shiny-server.js
@@ -335,7 +335,6 @@
       var reconnectingContent = '<button type="button" id="ss-reconnect-btn" class="ss-dialog-button">Reconnect ('+timeout+')</button><span class="ss-dialog-text">Trouble connecting to server</span>';
       $('<div id="ss-connect-dialog">'+reconnectingContent+'<div class="ss-clearfix"></div></div><div id="ss-gray-out"></div>').appendTo('body');
       $('#ss-reconnect-btn').click(function(){
-        timeout = 15;
         $('ss-reconnect-btn').prop('disabled', true);
         log("Attempting to reopen.");
         self._openConnection();

--- a/assets/shiny-server.js
+++ b/assets/shiny-server.js
@@ -7,7 +7,7 @@
       (function() {
         var loc = location.pathname;
         loc = loc.replace(/\/$/, '');
-        var sockjsUrl = loc + "/__sockjs__/";
+        var sockjsUrl = loc + "/__sockjs__/" + 'i=1234';
 
         exports.url = sockjsUrl;
 
@@ -23,7 +23,14 @@
           // relative difference between the above two dirs, we need to add 
           // something to each, like `/whatever/`, then we'd get '../b'.
           // This is why we append `__sockjs__` to each path before comparing.
-          function getRelativePath(from, to) {
+          function getRelativePath(from, to, includeLast) {
+
+						// The last element would otherwise get trimmed off, if you want it,
+            // add some garbage to the end that can be trimmed.
+            if (includeLast){
+              to += '/a';
+            }
+
             function trim(arr) {
               var start = 0;
               for (; start < arr.length; start++) {
@@ -64,7 +71,7 @@
           Shiny.createSocket = function() {
             try {
               if (window.parent.ShinyServer && window.parent.ShinyServer.multiplexer) {
-                var relURL = getRelativePath(window.parent.ShinyServer.url, sockjsUrl);
+                var relURL = getRelativePath(window.parent.ShinyServer.url, sockjsUrl, true);
                 return window.parent.ShinyServer.multiplexer.open(relURL);
               }
               log("Couldn't get multiplexer: multiplexer not found in parent");

--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -195,3 +195,10 @@ log_as_user {
   at $ server location;
   maxcount 1;
 }
+
+disable_reconnect {
+  desc "When a user's connection to the server is interrupted, Shiny Server will offer them a dialog that allows them to reconnect to their existing Shiny session for 15 seconds. This implies that the server will keep the Shiny session active on the server for an extra 15 seconds after a user disconnects in case they reconnect. After the 15 seconds, the user's session will be reaped and they will be notified and offered an opportunity to refresh the page. If this setting is true, the server will immediately reap the session of any user who is disconnected.";
+  param Boolean [enabled] "Whether or not to offer to automatically reconnect disconnected users." false;
+  at $;
+  maxcount 1;
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -165,11 +165,11 @@ var ssjs = Handlebars.compile(ssjsTemplate);
 var allProtocols = ['websocket', 'xdr-streaming', 'xhr-streaming', 
   'iframe-eventsource', 'iframe-htmlfile', 'xdr-polling', 
   'xhr-polling', 'iframe-xhr-polling', 'jsonp-polling'];
-function protocolsToJs(prots){
+function renderSSJS(prots, reconnect){
   var protStr = "['" + prots.join("','") + "']";
-  return ssjs({protocols: protStr})
+  return ssjs({protocols: protStr, reconnect: reconnect ? 'true' : 'false'});
 }
-var renderedSSJS = protocolsToJs(allProtocols);
+var renderedSSJS = renderSSJS(allProtocols, true);
 
 app.use(connect_util.filterByRegex(
   /\b__assets__\/.+/,
@@ -262,7 +262,10 @@ var loadConfig_p = qutil.serialized(function() {
     if (configRouter.disabledProtocols && configRouter.disabledProtocols.length > 0){
       logger.info("Disabled protocols: " + configRouter.disabledProtocols.join(","));
     }
-    renderedSSJS = protocolsToJs(prots);
+    
+    var reconnect = configRouter.reconnect;
+
+    renderedSSJS = renderSSJS(prots, reconnect);
 
     return createLogger_p(configRouter.accessLogSpec)
     .then(function(logfunc) {

--- a/lib/proxy/multiplex.js
+++ b/lib/proxy/multiplex.js
@@ -78,7 +78,7 @@ function MultiplexSocket(conn) {
         } else{
 					// It must be a relative path, compute the absolute path for SockJS
           var parUrl = conn.url;
-          var ind = parUrl.search(/\/i=/);
+          var ind = parUrl.search(/\/[no]=/);
           if (ind !== -1){
             parUrl = parUrl.substring(0, ind);
           }

--- a/lib/proxy/multiplex.js
+++ b/lib/proxy/multiplex.js
@@ -120,6 +120,7 @@ function MultiplexChannel(id, conn, properties) {
   this.$id = id;  // The channel id
   this.$conn = conn;  // The underlying SockJS connection
   _.extend(this, properties);  // Apply extra properties to this object
+  this.readyState = this.$conn.getReadyState();
   assert(this.readyState === 1); // copied from the (definitely active) conn
 }
 util.inherits(MultiplexChannel, events.EventEmitter);

--- a/lib/proxy/multiplex.js
+++ b/lib/proxy/multiplex.js
@@ -76,13 +76,13 @@ function MultiplexSocket(conn) {
           // The parent request will just pass an empty string.
           payload = conn.url;
         } else{
-          // It must be a relative path, compute the absolute path for SockJS
+					// It must be a relative path, compute the absolute path for SockJS
           var parUrl = conn.url;
-          var ind = parUrl.indexOf('/__sockjs__/');
+          var ind = parUrl.search(/\/i=/);
           if (ind !== -1){
             parUrl = parUrl.substring(0, ind);
           }
-          payload = path.join(parUrl, payload) + '/__sockjs__/';
+          payload = path.join(parUrl, payload);
         }
 
         // It's a request to open a new channel with the given id.

--- a/lib/proxy/multiplex.js
+++ b/lib/proxy/multiplex.js
@@ -54,7 +54,7 @@ function MultiplexSocket(conn) {
   });
   conn.on('data', function(message) {
     // Message received from physical connection; parse and dispatch it
-    var message = parseMultiplexData(message);
+    message = parseMultiplexData(message);
     if (!message) {
       logger.warn('Invalid multiplex packet received');
       conn.close();
@@ -90,7 +90,7 @@ function MultiplexSocket(conn) {
         // so let's copy the properties from the actual connection. We'll
         // overwrite the `url` though, to use the channel's URL.
         var properties = _.extend(_.pick(conn, connectionProps), {url: payload});
-        var channel = new MultiplexChannel(id, conn, properties);
+        channel = new MultiplexChannel(id, conn, properties);
         self.$channels[id] = channel;
         self.emit('connection', channel);
       } else {
@@ -165,7 +165,7 @@ function parseMultiplexData(msg) {
       id: m[1],
       method: m[2],
       payload: m[3]
-    }
+    };
 
     switch (msg.method) {
       case 'm':

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -16,6 +16,24 @@ var events = require('events');
 var crypto = require('crypto');
 var _ = require('underscore');
 
+function getInfo(conn){
+  var m = /\/__sockjs__\/([no])=(\w+)\//.exec(conn.pathname);
+  if (!m || m.length < 3){
+    logger.warn("Invalid sockjs URL.");
+    conn.close();
+    return conn;
+  }
+  var id = m[2];
+
+  // Whether the client is claiming that this ID is new or not.
+  var existing = m[1] === 'o';
+  return {id: id, existing: existing};
+}
+
+function RobustConn() {
+}
+util.inherits(RobustConn, events.EventEmitter);
+
 module.exports = RobustSockJS;
 function RobustSockJS(){
 	this.connections = {};
@@ -27,20 +45,15 @@ function RobustSockJS(){
   // new()s one.
   // Robust is just an encapsulated abstraction for taking these underlying things.
 	this.robustify = function(conn){
-    var m = /\/__sockjs__\/([no])=(\w+)\//.exec(conn.pathname);
-		if (!m || m.length < 3){
-			logger.warn("Invalid sockjs URL.");
-			conn.close();
-			return conn;
-		}
-		var id = m[2];
+    var info = getInfo(conn);
+    var id = conn.id;
+    var existing = conn.existing;
 
-    // Whether the client is claiming that this ID is new or not.
-    var existing = m[1] === 'o';
+    // The robust connection object to be returned.
+		var robustConn;
 
-		var oldConn = null;
-		var robustConn = null;
 		if (self.connections[id]){
+      // We found this ID in our table.
       if (!existing){
         // The client was intending to create a new connection, but we already
         // have this ID. Either a very unlikely collision or a cache issue.
@@ -57,31 +70,24 @@ function RobustSockJS(){
 			// swap in the new one.
 			robustConn = self.connections[id];
 
-      // Clear out any pending close/end messages
+      // Restore the original emit method so we don't see the bubbled 
+      // close/end events on our RobustConn.
+      robustConn._conn.emit = robustConn._conn._oldEmit;
+      // Close the underlying stale SockJS Connection
+      robustConn._conn.close();
+
+      // Clear out any pending close/end messages, as we no longer plan to close.
       if (robustConn._withheld){
         robustConn._withheld.events = [];
         clearTimeout(robustConn._withheld.timer);
         robustConn._withheld.timer = 0;
       }
 
-      // Copy various properties over
-      // FIXME: We're leaking too much of the underlying connection into the 
-      // upper abstraction here. We should only have a subset of documented methods
-      // that work. Getters for any property that could be used elsewhere.
-      _.extend(robustConn, _.pick(conn, connectionProps));
-
-			robustConn.close = function(){
-				conn.close.apply(conn, arguments);
-			};
-
       // Write any buffered events to the new connection
       var args;
       while ((args = robustConn._buffer.shift())){
         conn.write.apply(conn, args.arg);
       }
-		
-			// Store a record of the old connection so we can close it.
-			oldConn = robustConn._originalConn;
 		} else {
       if (existing){
         // The client expected us to have a record of this ID and we do not.
@@ -92,31 +98,41 @@ function RobustSockJS(){
           conn.close();
         }, 100);
       }
-
-			// This is a new connection. Create a robustConn object.
-      // Copy the properties over to the new object so it looks more like 
-      // a WebSocket.
-      robustConn = _.clone(conn);
+      robustConn = new RobustConn();
       robustConn._buffer = [];
 		}
 
-		robustConn._originalConn = conn;
+    // Copy various properties over
+    _.extend(robustConn, {
+      _conn: conn,
+      close: function(){ conn.close.apply(conn, arguments); },
+      write: function(){
+        // Write if this connection is ready.
+        if (conn.readyState === 1){
+          conn.write.apply(conn, arguments);
+        } else {
+          // Otherwise, buffer.
+          robustConn._buffer.push({arg: arguments});
+        }
+      },
+      _readyState: conn.readyState,
+      getReadyState: function(){
+        // We won't want to actually expose the ready state of the connection,
+        // as it may come and go. We want to be in a good ready state until 
+        // we're shutting down.
+        return robustConn._readyState;
+      },
+      url: conn.url,
+      address: conn.address,
+      headers: conn.headers,
+    });
 
-    // Make write buffered
-    robustConn.write = function(){
-      if (conn.readyState === 1){
-        conn.write.apply(conn, arguments);
-      } else {
-        robustConn._buffer.push({arg: arguments});
-      }
-    };
-		
 		// Override the underlying connection's emit so we can echo.
-		var oldEmit = conn.emit;
+		conn._oldEmit = conn.emit;
 		conn.emit = function(type) {
       function doEmit(){
 				robustConn.emit.apply(robustConn, arguments);
-				oldEmit.apply(conn, arguments);
+				conn._oldEmit.apply(conn, arguments);
       }
 
 			if (type === 'end' || type === 'close'){
@@ -133,6 +149,7 @@ function RobustSockJS(){
               doEmit.apply(null, evt.arg);
             }
             delete self.connections[id];
+            robustConn._readyState = 3; // Mark as closed.
           }, 15 * 1000);
         }
 			} else {
@@ -140,11 +157,7 @@ function RobustSockJS(){
 			}
 		};
 
-		if (oldConn){
-			// Assign, then close the old connection
-			logger.debug("Replaced and closing SockJS connection #" + id);
-			oldConn.close();
-		} else {
+    if (!self.connections[id]){
 			// Add to registry
 			logger.trace("Storing persistent connection with ID: " + id);
 			self.connections[id] = robustConn;
@@ -153,8 +166,3 @@ function RobustSockJS(){
 		return robustConn;
 	};
 }
-
-// Properties to copy from sockjs connection to MultiplexChannel
-var connectionProps = ['readable', 'writable', 'remoteAddress',
-  'remotePort', 'address', 'headers', 'url', 'pathname',
-  'prefix', 'protocol', 'readyState'];

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -85,7 +85,7 @@ function RobustSockJSRegistry(timeout){
   // others who will continue to reference it. So we need to keep avoid
   // overwriting the reference, but just copy in methods and properties.
   this._replaceConnection = function(id, robustConn){
-    var properties = ['_buffer', '_conn', '_readyState', 'url', 'address', 'headers'];
+    var properties = ['_buffer', '_conn', '_readyState', 'url', 'address', 'headers', '_withheld'];
     var methods = ['getReadyState', 'write'];
 
     var conn = self._connections[id];
@@ -201,6 +201,7 @@ function RobustSockJSRegistry(timeout){
     this.url = conn.url;
     this.address = conn.address;
     this.headers = conn.headers;
+    this._withheld = {timer: null, events: []};
 
     // Override the underlying connection's emit so we can echo from our
     // RobustConn.
@@ -213,9 +214,6 @@ function RobustSockJSRegistry(timeout){
       }
       if (type === 'end' || type === 'close'){
         logger.trace("Withholding event '" + type + "' from robust connection " + id);
-        if (!robustConn._withheld){
-          robustConn._withheld = {timer: null, events: []};
-        }
         robustConn._withheld.events.push({arg: arguments});
         if (!robustConn._withheld.timer){
           robustConn._withheld.timer = setTimeout(function(){

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -11,23 +11,51 @@
  *
  */
 
-var websocket = require('faye-websocket');
 var util = require('util');
 var events = require('events');
+var crypto = require('crypto');
+var _ = require('underscore');
 
 module.exports = RobustSockJS;
 function RobustSockJS(){
+	this.connections = {};
+
+	var self = this;
 	this.robustify = function(conn){
+		var id = crypto.randomBytes(32).toString('hex')
+		conn._robustId = id;
+
+		if (conn.readyState === 1) {
+			conn.write('0|i|' + id);
+		} else {
+			console.log("Conn not ready");
+		}
+
+		// Copy the properties over to the new object so it looks more like 
+		// a WebSocket.
+		var robustConn = _.clone(conn, connectionProps);
+		
 		// Override the underlying connection's emit so we can echo.
 		var oldEmit = conn.emit;
 		conn.emit = function(type) {
 			var emitArgs = arguments;
 			if (type === 'end' || type === 'close'){
-				// FIXME: Hold back
-				oldEmit.apply(conn, arguments);
+				// FIXME: Hold back events
+				delete self.connections[id];
 			} else {
-				oldEmit.apply(conn, arguments);
 			}
+			robustConn.emit.apply(robustConn, arguments);
+			oldEmit.apply(conn, arguments);
 		};
+		
+		// Add to registry
+		this.connections[id] = robustConn;
+
+		return robustConn;
 	};
 }
+
+// Properties to copy from sockjs connection to MultiplexChannel
+var connectionProps = ['readable', 'writable', 'remoteAddress',
+  'remotePort', 'address', 'headers', 'url', 'pathname',
+  'prefix', 'protocol', 'readyState'];

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -38,36 +38,72 @@ function RobustSockJS(){
 			// swap in the new one.
 			robustConn = self.connections[id];
 
-      // TODO: what's the underscore-ism for bringing in all these methods without wiping
-      // the robustConn object, which is being pointed to by other parties.
-			// Ensure that the public methods we use are current.
-			robustConn.write = function(){
-				conn.write.apply(conn, arguments);
-			};
+      // Clear out any pending close/end messages
+      if (robustConn._withheld){
+        robustConn._withheld.events = [];
+        clearTimeout(robustConn._withheld.timer);
+        robustConn._withheld.timer = 0;
+      }
+
+      // Copy various properties over
+      _.extend(robustConn, _.pick(conn, connectionProps));
+
 			robustConn.close = function(){
 				conn.close.apply(conn, arguments);
 			};
+
+      // Write any buffered events to the new connection
+      var args;
+      while ((args = robustConn._buffer.shift())){
+        conn.write.apply(conn, args.arg);
+      }
 		
 			// Store a record of the old connection so we can close it.
 			oldConn = robustConn._originalConn;
 		} else {
 			// This is a new connection. Create a robustConn object.
-			robustConn = _.clone(conn);
-			robustConn._originalConn = conn;
+      // Copy the properties over to the new object so it looks more like 
+      // a WebSocket.
+      robustConn = _.clone(conn);
+      robustConn._buffer = [];
 		}
 
-		// Copy the properties over to the new object so it looks more like 
-		// a WebSocket.
+		robustConn._originalConn = conn;
+
+    // Make write buffered
+    robustConn.write = function(){
+      if (conn.readyState === 1){
+        conn.write.apply(conn, arguments);
+      } else {
+        robustConn._buffer.push({arg: arguments});
+      }
+    };
 		
 		// Override the underlying connection's emit so we can echo.
 		var oldEmit = conn.emit;
 		conn.emit = function(type) {
-			if (type === 'end' || type === 'close'){
-				// FIXME: Emit eventually...
-				// delete self.connections[id];
-			} else {
+      function doEmit(){
 				robustConn.emit.apply(robustConn, arguments);
 				oldEmit.apply(conn, arguments);
+      }
+
+			if (type === 'end' || type === 'close'){
+        if (!robustConn._withheld){          
+          robustConn._withheld = {timer: null, events: []};
+        }
+        robustConn._withheld.events.push({arg: arguments});
+        if (!robustConn._withheld.timer){
+          robustConn._withheld.timer = setTimeout(function(){
+            var evt;
+            while ((evt = robustConn._withheld.events.pop())){
+              doEmit.apply(null, evt.arg);
+            }
+          }, 15 * 1000);
+        }
+
+				// delete self.connections[id];
+			} else {
+        doEmit.apply(null, arguments);
 			}
 		};
 

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -41,7 +41,14 @@ function writeFatalConn(conn, msg){
 }
 
 module.exports = RobustSockJSRegistry;
-function RobustSockJSRegistry(){
+// @param timeout The number of seconds to retain an abruptly closed connection
+//   before passing along its closed and/or end events.
+function RobustSockJSRegistry(timeout){
+  if (!timeout){
+    timeout = 15;
+  }
+  this._timeout = timeout * 1000;
+
   this._connections = {};
 
   var self = this;
@@ -215,21 +222,21 @@ function RobustSockJSRegistry(){
         robustConn._withheld.events.push({arg: arguments});
         if (!robustConn._withheld.timer){
           robustConn._withheld.timer = setTimeout(function(){
-          // If time has passed, actually kill the connection by emitting the
-          // withheld events of close and/or end.
-          var evt;
-          while ((evt = robustConn._withheld.events.pop())){
-            doEmit.apply(null, evt.arg);
-          }
-          logger.debug("Closing robust connection " + id);
-          delete self._connections[id];
-          robustConn._readyState = 3; // Mark as closed.
-        }, 15 * 1000);
+            // If time has passed, actually kill the connection by emitting the
+            // withheld events of close and/or end.
+            var evt;
+            while ((evt = robustConn._withheld.events.pop())){
+              doEmit.apply(null, evt.arg);
+            }
+            logger.debug("Closing robust connection " + id);
+            delete self._connections[id];
+            robustConn._readyState = 3; // Mark as closed.
+          }, self._timeout);
+        }
+      } else {
+        doEmit.apply(null, arguments);
       }
-    } else {
-      doEmit.apply(null, arguments);
-    }
+    };
   };
-  }
-util.inherits(this.RobustConn, events.EventEmitter);
+  util.inherits(this.RobustConn, events.EventEmitter);
 }

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -41,8 +41,16 @@ function RobustSockJS(){
 		var oldConn = null;
 		var robustConn = null;
 		if (self.connections[id]){
-      //FIXME: if the client is intending to create a new connection, but we already
-      // have this ID. What happens?
+      if (!existing){
+        // The client was intending to create a new connection, but we already
+        // have this ID. Either a very unlikely collision or a cache issue.
+        logger.warn("RobustSockJS collision: " + id);
+        conn.write('0|r|Unable to open connection.');
+        setTimeout(function(){
+          conn.close();
+        }, 100);
+        return;
+      }
 
 			// This must be a reconnect. We might not yet know that the client
 			// was closed. So make the best effort to close the old one, and hot
@@ -124,10 +132,9 @@ function RobustSockJS(){
             while ((evt = robustConn._withheld.events.pop())){
               doEmit.apply(null, evt.arg);
             }
+            delete self.connections[id];
           }, 15 * 1000);
         }
-
-				// FIXME: memory leak delete self.connections[id];
 			} else {
         doEmit.apply(null, arguments);
 			}

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -38,6 +38,8 @@ function RobustSockJS(){
 			// swap in the new one.
 			robustConn = self.connections[id];
 
+      // TODO: what's the underscore-ism for bringing in all these methods without wiping
+      // the robustConn object, which is being pointed to by other parties.
 			// Ensure that the public methods we use are current.
 			robustConn.write = function(){
 				conn.write.apply(conn, arguments);

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -30,139 +30,155 @@ function getInfo(conn){
   return {id: id, existing: existing};
 }
 
-function RobustConn() {
+function RobustConn(conn) {
+  // Extend eventEmitter
+  events.EventEmitter.call(this); 
+
+  var robustConn = this;
+
+  this._buffer = [];
+  this._conn = conn;
+  this.close = function(){ conn.close.apply(conn, arguments); };
+  this.write = function(){
+    // Write if this connection is ready.
+    if (conn.readyState === 1){
+      conn.write.apply(conn, arguments);
+    } else {
+      // Otherwise, buffer.
+      robustConn._buffer.push({arg: arguments});
+    }
+  };
+  this._readyState = conn.readyState;
+  this.getReadyState = function(){
+    // We won't want to actually expose the ready state of the connection,
+    // as it may come and go. We want to be in a good ready state until
+    // we're shutting down.
+    return robustConn._readyState;
+  };
+  this.url = conn.url;
+  this.address = conn.address;
+  this.headers = conn.headers;
+
+  // Override the underlying connection's emit so we can echo from our 
+  // RobustConn.
+  conn._oldEmit = conn.emit;
+  conn.emit = function(type) {
+    function doEmit(){
+      robustConn.emit.apply(robustConn, arguments);
+      conn._oldEmit.apply(conn, arguments);
+    }
+
+    if (type === 'end' || type === 'close'){
+      if (!robustConn._withheld){
+        robustConn._withheld = {timer: null, events: []};
+      }
+      robustConn._withheld.events.push({arg: arguments});
+      if (!robustConn._withheld.timer){
+        robustConn._withheld.timer = setTimeout(function(){
+          // If time has passed, actually kill the connection by emitting the
+          // withheld events of close and/or end.
+          var evt;
+          while ((evt = robustConn._withheld.events.pop())){
+            doEmit.apply(null, evt.arg);
+          }
+          delete self.connections[id];
+          robustConn._readyState = 3; // Mark as closed.
+        }, 15 * 1000);
+      }
+    } else {
+      doEmit.apply(null, arguments);
+    }
+  };
 }
 util.inherits(RobustConn, events.EventEmitter);
 
-module.exports = RobustSockJS;
-function RobustSockJS(){
-	this.connections = {};
+// Write a fatal message to a connection and then close it after
+// giving it a chance to write the message.
+function writeFatalConn(conn, msg){
+  conn.write('0|r|' + msg);
+  setTimeout(function(){
+    conn.close();
+  }, 100);
+}
 
-	var self = this;
-  // Robustify should just look up whether it exists, and deal with the matrix
-  // of whether it does/expected to exist
-  // THen once it finds a connection, it just returns the connection. Otherwise, it 
-  // new()s one.
-  // Robust is just an encapsulated abstraction for taking these underlying things.
+module.exports = RobustSockJSRegistry;
+function RobustSockJSRegistry(){
+  this.connections = {};
+
+  var self = this;
+
+  // Replace the existing record of a connection in our connections table with
+  // this new conncetion for the given ID.
+  this.replaceConnection = function(id, conn){
+    // This is a reconnect. We might not yet know that the client
+    // was closed. So make the best effort to close the old one, and hot
+    // swap in the new one.
+    var robustConn = self.connections[id];
+
+    // Restore the original emit method so we don't see the bubbled
+    // close/end events on our RobustConn.
+    robustConn._conn.emit = robustConn._conn._oldEmit;
+    // Close the underlying stale SockJS Connection
+    robustConn._conn.close();
+
+    // Clear out any pending close/end messages, as we no longer plan to close.
+    if (robustConn._withheld){
+      robustConn._withheld.events = [];
+      clearTimeout(robustConn._withheld.timer);
+      robustConn._withheld.timer = 0;
+    }
+
+    // Write any buffered events to the new connection
+    var args;
+    while ((args = robustConn._buffer.shift())){
+      conn.write.apply(conn, args.arg);
+    }
+
+    // Create and store the new RobustConn.
+    robustConn = new RobustConn(conn);
+    self.connections[id] = robustConn;
+  };
+
+  // Handle the incoming connection, either mapping it to an existing session
+  // or creating a new Robust connection encapsulation for it.
+  // In the case of an error, it will close the given connection with an error
+  // message and return fasley.
 	this.robustify = function(conn){
     var info = getInfo(conn);
-    var id = conn.id;
-    var existing = conn.existing;
+    var id = info.id;
+    var existing = info.existing;
 
     // The robust connection object to be returned.
-		var robustConn;
+    var robustConn;
 
-		if (self.connections[id]){
-      // We found this ID in our table.
-      if (!existing){
-        // The client was intending to create a new connection, but we already
-        // have this ID. Either a very unlikely collision or a cache issue.
+    if (self.connections[id]){
+      // ID found in table
+
+      if (existing){
+        // Reconnecting to an existing session
+        logger.trace("Reconnecting to robust connection: " + id);
+        self.replaceConnection(id, conn);
+      } else {
+        // Trying to create a new session with a colliding ID
         logger.warn("RobustSockJS collision: " + id);
-        conn.write('0|r|Unable to open connection.');
-        setTimeout(function(){
-          conn.close();
-        }, 100);
+        writeFatalConn(conn, "Unable to open connection");
         return;
       }
+    } else {
+      // ID not found in table
 
-			// This must be a reconnect. We might not yet know that the client
-			// was closed. So make the best effort to close the old one, and hot
-			// swap in the new one.
-			robustConn = self.connections[id];
-
-      // Restore the original emit method so we don't see the bubbled 
-      // close/end events on our RobustConn.
-      robustConn._conn.emit = robustConn._conn._oldEmit;
-      // Close the underlying stale SockJS Connection
-      robustConn._conn.close();
-
-      // Clear out any pending close/end messages, as we no longer plan to close.
-      if (robustConn._withheld){
-        robustConn._withheld.events = [];
-        clearTimeout(robustConn._withheld.timer);
-        robustConn._withheld.timer = 0;
-      }
-
-      // Write any buffered events to the new connection
-      var args;
-      while ((args = robustConn._buffer.shift())){
-        conn.write.apply(conn, args.arg);
-      }
-		} else {
-      if (existing){
-        // The client expected us to have a record of this ID and we do not.
+      if (existing) {
+        // Trying to resume a session which we don't have a record of.
         logger.info("Disconnecting client because ID wasn't found.");
-        conn.write('0|r|Your session could not be resumed on the server.');
-        // Give it a chance to write.
-        setTimeout(function(){
-          conn.close();
-        }, 100);
+        writeFatalConn(conn, 'Your session could not be resumed on the server.');
+        return;
+      } else {
+        // Creating a new connection.
+        logger.trace("Creating a new robust connection: " + id);
+        self.connections[id] = new RobustConn(conn);
       }
-      robustConn = new RobustConn();
-      robustConn._buffer = [];
-		}
+    }
 
-    // Copy various properties over
-    _.extend(robustConn, {
-      _conn: conn,
-      close: function(){ conn.close.apply(conn, arguments); },
-      write: function(){
-        // Write if this connection is ready.
-        if (conn.readyState === 1){
-          conn.write.apply(conn, arguments);
-        } else {
-          // Otherwise, buffer.
-          robustConn._buffer.push({arg: arguments});
-        }
-      },
-      _readyState: conn.readyState,
-      getReadyState: function(){
-        // We won't want to actually expose the ready state of the connection,
-        // as it may come and go. We want to be in a good ready state until 
-        // we're shutting down.
-        return robustConn._readyState;
-      },
-      url: conn.url,
-      address: conn.address,
-      headers: conn.headers,
-    });
-
-		// Override the underlying connection's emit so we can echo.
-		conn._oldEmit = conn.emit;
-		conn.emit = function(type) {
-      function doEmit(){
-				robustConn.emit.apply(robustConn, arguments);
-				conn._oldEmit.apply(conn, arguments);
-      }
-
-			if (type === 'end' || type === 'close'){
-        if (!robustConn._withheld){          
-          robustConn._withheld = {timer: null, events: []};
-        }
-        robustConn._withheld.events.push({arg: arguments});
-        if (!robustConn._withheld.timer){
-          robustConn._withheld.timer = setTimeout(function(){
-            // If time has passed, actually kill the connection by emitting the
-            // withheld events of close and/or end.
-            var evt;
-            while ((evt = robustConn._withheld.events.pop())){
-              doEmit.apply(null, evt.arg);
-            }
-            delete self.connections[id];
-            robustConn._readyState = 3; // Mark as closed.
-          }, 15 * 1000);
-        }
-			} else {
-        doEmit.apply(null, arguments);
-			}
-		};
-
-    if (!self.connections[id]){
-			// Add to registry
-			logger.trace("Storing persistent connection with ID: " + id);
-			self.connections[id] = robustConn;
-		}
-
-		return robustConn;
-	};
+    return self.connections[id];
+  };
 }

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -34,6 +34,7 @@ function RobustSockJS(){
 		// Copy the properties over to the new object so it looks more like 
 		// a WebSocket.
 		var robustConn = _.clone(conn, connectionProps);
+		robustConn._originalConn = conn;
 		
 		// Override the underlying connection's emit so we can echo.
 		var oldEmit = conn.emit;
@@ -49,7 +50,7 @@ function RobustSockJS(){
 		};
 		
 		// Add to registry
-		this.connections[id] = robustConn;
+		self.connections[id] = robustConn;
 
 		return robustConn;
 	};

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -117,7 +117,7 @@ function RobustSockJSRegistry(timeout){
   // Handle the incoming connection, either mapping it to an existing session
   // or creating a new Robust connection encapsulation for it.
   // In the case of an error, it will close the given connection with an error
-  // message and return fasley.
+  // message and return falsey.
 	this.robustify = function(conn){
     var info = getInfo(conn);
     if (!info){
@@ -158,7 +158,7 @@ function RobustSockJSRegistry(timeout){
 
       if (existing) {
         // Trying to resume a session which we don't have a record of.
-        logger.info("Disconnecting client because ID wasn't found.");
+        logger.debug("Disconnecting client because ID wasn't found.");
         writeFatalConn(conn, 'Your session could not be resumed on the server.');
         return;
       } else {

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -22,13 +22,16 @@ function RobustSockJS(){
 
 	var self = this;
 	this.robustify = function(conn){
-    var m = /\/__sockjs__\/i=(\w+)\//.exec(conn.pathname);
-		if (!m || m.length < 2){
+    var m = /\/__sockjs__\/([no])=(\w+)\//.exec(conn.pathname);
+		if (!m || m.length < 3){
 			logger.warn("Invalid sockjs URL.");
 			conn.close();
 			return conn;
 		}
-		var id = m[1];
+		var id = m[2];
+
+    // Whether the client is claiming that this ID is new or not.
+    var existing = m[1] === 'o';
 
 		var oldConn = null;
 		var robustConn = null;
@@ -61,6 +64,16 @@ function RobustSockJS(){
 			// Store a record of the old connection so we can close it.
 			oldConn = robustConn._originalConn;
 		} else {
+      if (existing){
+        // The client expected us to have a record of this ID and we do not.
+        logger.info("Disconnecting client because ID wasn't found.");
+        conn.write('0|r|Your session could not be resumed on the server.');
+        // Give it a chance to write.
+        setTimeout(function(){
+          conn.close();
+        }, 100);
+      }
+
 			// This is a new connection. Create a robustConn object.
       // Copy the properties over to the new object so it looks more like 
       // a WebSocket.

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -16,12 +16,13 @@ var events = require('events');
 var crypto = require('crypto');
 var _ = require('underscore');
 
+// If error, closes the connection and returns falsey.
 function getInfo(conn){
   var m = /\/__sockjs__\/([no])=(\w+)\//.exec(conn.pathname);
   if (!m || m.length < 3){
     logger.warn("Invalid sockjs URL.");
     conn.close();
-    return conn;
+    return false;
   }
   var id = m[2];
 
@@ -29,75 +30,6 @@ function getInfo(conn){
   var existing = m[1] === 'o';
   return {id: id, existing: existing};
 }
-
-// We can't create a wholly new object, or we lose the references we've established
-// on this obj elsewhere.
-function RobustConn(conn, id, deleteCB) {
-  // Extend eventEmitter
-  events.EventEmitter.call(this);
-
-  var robustConn = this;
-
-  this._buffer = [];
-  this._conn = conn;
-  this.close = function(){ conn.close.apply(conn, arguments); };
-  this.write = function(){
-    // Write if this connection is ready.
-    if (conn.readyState === 1){
-      conn.write.apply(conn, arguments);
-    } else {
-      // Otherwise, buffer.
-      robustConn._buffer.push({arg: arguments});
-    }
-  };
-  this._readyState = conn.readyState;
-  this.getReadyState = function(){
-    // We won't want to actually expose the ready state of the connection,
-    // as it may come and go. We want to be in a good ready state until
-    // we're shutting down.
-    return robustConn._readyState;
-  };
-  this.url = conn.url;
-  this.address = conn.address;
-  this.headers = conn.headers;
-
-  // Override the underlying connection's emit so we can echo from our
-  // RobustConn.
-  conn._oldEmit = conn.emit;
-  conn.emit = function(type) {
-    function doEmit(){
-      //FIXME: this is busted. we're emitting on these disposable objects that
-      // aren't going to be copied over the the real object others are pointing to.
-      // We need to emit on the connections[id] object.
-      robustConn.emit.apply(robustConn, arguments);
-      conn._oldEmit.apply(conn, arguments);
-    }
-
-    if (type === 'end' || type === 'close'){
-      logger.trace("Withholding event '" + type + "' from robust connection " + id);
-      if (!robustConn._withheld){
-        robustConn._withheld = {timer: null, events: []};
-      }
-      robustConn._withheld.events.push({arg: arguments});
-      if (!robustConn._withheld.timer){
-        robustConn._withheld.timer = setTimeout(function(){
-          // If time has passed, actually kill the connection by emitting the
-          // withheld events of close and/or end.
-          var evt;
-          while ((evt = robustConn._withheld.events.pop())){
-            doEmit.apply(null, evt.arg);
-          }
-          logger.debug("Closing robust connection " + id);
-          deleteCB();
-          robustConn._readyState = 3; // Mark as closed.
-        }, 15 * 1000);
-      }
-    } else {
-      doEmit.apply(null, arguments);
-    }
-  };
-}
-util.inherits(RobustConn, events.EventEmitter);
 
 // Write a fatal message to a connection and then close it after
 // giving it a chance to write the message.
@@ -110,17 +42,17 @@ function writeFatalConn(conn, msg){
 
 module.exports = RobustSockJSRegistry;
 function RobustSockJSRegistry(){
-  this.connections = {};
+  this._connections = {};
 
   var self = this;
 
   // Replace the existing record of a connection in our connections table with
   // this new conncetion for the given ID.
-  this.retireConnection = function(id, conn){
+  this._retireConnection = function(id, conn){
     // This is a reconnect. We might not yet know that the client
     // was closed. So make the best effort to close the old one, and hot
     // swap in the new one.
-    var robustConn = self.connections[id];
+    var robustConn = self._connections[id];
 
     // Restore the original emit method so we don't see the bubbled
     // close/end events on our RobustConn.
@@ -145,11 +77,11 @@ function RobustSockJSRegistry(){
   // We can't assign to the connections map since we gave that reference to
   // others who will continue to reference it. So we need to keep avoid
   // overwriting the reference, but just copy in methods and properties.
-  this.replaceConnection = function(id, robustConn){
+  this._replaceConnection = function(id, robustConn){
     var properties = ['_buffer', '_conn', '_close', '_readyState', 'url', 'address', 'headers'];
     var methods = ['_close', 'getReadyState', 'write'];
 
-    var conn = self.connections[id];
+    var conn = self._connections[id];
 
     // Copy properties
     _.each(properties, function(p){
@@ -181,13 +113,17 @@ function RobustSockJSRegistry(){
   // message and return fasley.
 	this.robustify = function(conn){
     var info = getInfo(conn);
+    if (!info){
+      writeFatalConn(conn, 'Invalid SockJS URL format.');
+      return;
+    }
     var id = info.id;
     var existing = info.existing;
 
     // The robust connection object to be returned.
     var robustConn;
 
-    if (self.connections[id]){
+    if (self._connections[id]){
       // ID found in table
 
       if (existing){
@@ -196,16 +132,14 @@ function RobustSockJSRegistry(){
 
         // Retire the old connection, writing any buffered data into the new 
         // conn.
-        self.retireConnection(id, conn);
+        self._retireConnection(id, conn);
 
         // Create and store the new RobustConn.
-        robustConn = new RobustConn(conn, id, function(){
-          delete self.connections[id];
-        });
+        robustConn = new self.RobustConn(conn, id);
 
         // Effectively a pass-by-ref version of: 
-        //   `self.connections[id] = robustConn`
-        self.replaceConnection(id, robustConn);
+        //   `self._connections[id] = robustConn`
+        self._replaceConnection(id, robustConn);
       } else {
         // Trying to create a new session with a colliding ID
         logger.warn("RobustSockJS collision: " + id);
@@ -223,12 +157,79 @@ function RobustSockJSRegistry(){
       } else {
         // Creating a new connection.
         logger.debug("Creating a new robust connection: " + id);
-        self.connections[id] = new RobustConn(conn, id, function(){
-          delete self.connections[id];
-        });
+        self._connections[id] = new self.RobustConn(conn, id);
       }
     }
 
-    return self.connections[id];
+    return self._connections[id];
   };
+
+  // We can't create a wholly new object, or we lose the references we've established
+  // on this obj elsewhere.
+  this.RobustConn = function(conn, id) {
+    // Extend eventEmitter
+    events.EventEmitter.call(this);
+
+    var robustConn = this;
+
+    this._buffer = [];
+    this._conn = conn;
+    this.close = function(){ conn.close.apply(conn, arguments); };
+    this.write = function(){
+      // Write if this connection is ready.
+      if (conn.readyState === 1){
+        conn.write.apply(conn, arguments);
+      } else {
+        // Otherwise, buffer.
+        robustConn._buffer.push({arg: arguments});
+      }
+    };
+    this._readyState = conn.readyState;
+    this.getReadyState = function(){
+      // We won't want to actually expose the ready state of the connection,
+      // as it may come and go. We want to be in a good ready state until
+      // we're shutting down.
+      return robustConn._readyState;
+    };
+    this.url = conn.url;
+    this.address = conn.address;
+    this.headers = conn.headers;
+
+    // Override the underlying connection's emit so we can echo from our
+    // RobustConn.
+    conn._oldEmit = conn.emit;
+    conn.emit = function(type) {
+      function doEmit(){
+        //FIXME: this is busted. we're emitting on these disposable objects that
+        // aren't going to be copied over the the real object others are pointing to.
+        // We need to emit on the connections[id] object.
+        robustConn.emit.apply(robustConn, arguments);
+        conn._oldEmit.apply(conn, arguments);
+      }
+
+      if (type === 'end' || type === 'close'){
+        logger.trace("Withholding event '" + type + "' from robust connection " + id);
+        if (!robustConn._withheld){
+          robustConn._withheld = {timer: null, events: []};
+        }
+        robustConn._withheld.events.push({arg: arguments});
+        if (!robustConn._withheld.timer){
+          robustConn._withheld.timer = setTimeout(function(){
+          // If time has passed, actually kill the connection by emitting the
+          // withheld events of close and/or end.
+          var evt;
+          while ((evt = robustConn._withheld.events.pop())){
+            doEmit.apply(null, evt.arg);
+          }
+          logger.debug("Closing robust connection " + id);
+          delete self._connections[id];
+          robustConn._readyState = 3; // Mark as closed.
+        }, 15 * 1000);
+      }
+    } else {
+      doEmit.apply(null, arguments);
+    }
+  };
+  }
+util.inherits(this.RobustConn, events.EventEmitter);
 }

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -30,9 +30,11 @@ function getInfo(conn){
   return {id: id, existing: existing};
 }
 
-function RobustConn(conn) {
+// We can't create a wholly new object, or we lose the references we've established
+// on this obj elsewhere.
+function RobustConn(conn, id, deleteCB) {
   // Extend eventEmitter
-  events.EventEmitter.call(this); 
+  events.EventEmitter.call(this);
 
   var robustConn = this;
 
@@ -59,16 +61,20 @@ function RobustConn(conn) {
   this.address = conn.address;
   this.headers = conn.headers;
 
-  // Override the underlying connection's emit so we can echo from our 
+  // Override the underlying connection's emit so we can echo from our
   // RobustConn.
   conn._oldEmit = conn.emit;
   conn.emit = function(type) {
     function doEmit(){
+      //FIXME: this is busted. we're emitting on these disposable objects that
+      // aren't going to be copied over the the real object others are pointing to.
+      // We need to emit on the connections[id] object.
       robustConn.emit.apply(robustConn, arguments);
       conn._oldEmit.apply(conn, arguments);
     }
 
     if (type === 'end' || type === 'close'){
+      logger.trace("Withholding event '" + type + "' from robust connection " + id);
       if (!robustConn._withheld){
         robustConn._withheld = {timer: null, events: []};
       }
@@ -81,7 +87,8 @@ function RobustConn(conn) {
           while ((evt = robustConn._withheld.events.pop())){
             doEmit.apply(null, evt.arg);
           }
-          delete self.connections[id];
+          logger.debug("Closing robust connection " + id);
+          deleteCB();
           robustConn._readyState = 3; // Mark as closed.
         }, 15 * 1000);
       }
@@ -109,7 +116,7 @@ function RobustSockJSRegistry(){
 
   // Replace the existing record of a connection in our connections table with
   // this new conncetion for the given ID.
-  this.replaceConnection = function(id, conn){
+  this.retireConnection = function(id, conn){
     // This is a reconnect. We might not yet know that the client
     // was closed. So make the best effort to close the old one, and hot
     // swap in the new one.
@@ -133,10 +140,39 @@ function RobustSockJSRegistry(){
     while ((args = robustConn._buffer.shift())){
       conn.write.apply(conn, args.arg);
     }
+  };
 
-    // Create and store the new RobustConn.
-    robustConn = new RobustConn(conn);
-    self.connections[id] = robustConn;
+  // We can't assign to the connections map since we gave that reference to
+  // others who will continue to reference it. So we need to keep avoid
+  // overwriting the reference, but just copy in methods and properties.
+  this.replaceConnection = function(id, robustConn){
+    var properties = ['_buffer', '_conn', '_close', '_readyState', 'url', 'address', 'headers'];
+    var methods = ['_close', 'getReadyState', 'write'];
+
+    var conn = self.connections[id];
+
+    // Copy properties
+    _.each(properties, function(p){
+      conn[p] = robustConn[p];
+    });
+
+    // Copy methods
+    _.each(methods, function(m){
+      conn[m] = function(){
+        robustConn[m].apply(robustConn, arguments); 
+      };
+    });
+
+    // The original object has its eventEmitters already wired in, but now that
+    // we're using this new object, we want to use its events, too.
+    // Bubble events by overwriting the emit method (so we can capture all
+    // events).
+    // TODO: not a memory leak that we don't ever unregister, right?
+    var oldEmit = robustConn.emit;
+    robustConn.emit = function(){
+      oldEmit.apply(robustConn, arguments);
+      conn.emit.apply(conn, arguments);
+    };
   };
 
   // Handle the incoming connection, either mapping it to an existing session
@@ -156,8 +192,20 @@ function RobustSockJSRegistry(){
 
       if (existing){
         // Reconnecting to an existing session
-        logger.trace("Reconnecting to robust connection: " + id);
-        self.replaceConnection(id, conn);
+        logger.debug("Reconnecting to robust connection: " + id);
+
+        // Retire the old connection, writing any buffered data into the new 
+        // conn.
+        self.retireConnection(id, conn);
+
+        // Create and store the new RobustConn.
+        robustConn = new RobustConn(conn, id, function(){
+          delete self.connections[id];
+        });
+
+        // Effectively a pass-by-ref version of: 
+        //   `self.connections[id] = robustConn`
+        self.replaceConnection(id, robustConn);
       } else {
         // Trying to create a new session with a colliding ID
         logger.warn("RobustSockJS collision: " + id);
@@ -174,8 +222,10 @@ function RobustSockJSRegistry(){
         return;
       } else {
         // Creating a new connection.
-        logger.trace("Creating a new robust connection: " + id);
-        self.connections[id] = new RobustConn(conn);
+        logger.debug("Creating a new robust connection: " + id);
+        self.connections[id] = new RobustConn(conn, id, function(){
+          delete self.connections[id];
+        });
       }
     }
 

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -85,8 +85,8 @@ function RobustSockJSRegistry(timeout){
   // others who will continue to reference it. So we need to keep avoid
   // overwriting the reference, but just copy in methods and properties.
   this._replaceConnection = function(id, robustConn){
-    var properties = ['_buffer', '_conn', '_close', '_readyState', 'url', 'address', 'headers'];
-    var methods = ['_close', 'getReadyState', 'write'];
+    var properties = ['_buffer', '_conn', '_readyState', 'url', 'address', 'headers'];
+    var methods = ['getReadyState', 'write'];
 
     var conn = self._connections[id];
 
@@ -184,8 +184,8 @@ function RobustSockJSRegistry(timeout){
     this.close = function(){ conn.close.apply(conn, arguments); };
     this.write = function(){
       // Write if this connection is ready.
-      if (conn.readyState === 1){
-        conn.write.apply(conn, arguments);
+      if (robustConn._readyState === 1){
+        robustConn._conn.write.apply(robustConn._conn, arguments);
       } else {
         // Otherwise, buffer.
         robustConn._buffer.push({arg: arguments});
@@ -207,13 +207,10 @@ function RobustSockJSRegistry(timeout){
     conn._oldEmit = conn.emit;
     conn.emit = function(type) {
       function doEmit(){
-        //FIXME: this is busted. we're emitting on these disposable objects that
-        // aren't going to be copied over the the real object others are pointing to.
         // We need to emit on the connections[id] object.
         robustConn.emit.apply(robustConn, arguments);
         conn._oldEmit.apply(conn, arguments);
       }
-
       if (type === 'end' || type === 'close'){
         logger.trace("Withholding event '" + type + "' from robust connection " + id);
         if (!robustConn._withheld){

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -1,0 +1,33 @@
+/*
+ * robust-sockjs.js
+ *
+ * Copyright (C) 2009-13 by RStudio, Inc.
+ *
+ * This program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+var websocket = require('faye-websocket');
+var util = require('util');
+var events = require('events');
+
+module.exports = RobustSockJS;
+function RobustSockJS(){
+	this.robustify = function(conn){
+		// Override the underlying connection's emit so we can echo.
+		var oldEmit = conn.emit;
+		conn.emit = function(type) {
+			var emitArgs = arguments;
+			if (type === 'end' || type === 'close'){
+				// FIXME: Hold back
+				oldEmit.apply(conn, arguments);
+			} else {
+				oldEmit.apply(conn, arguments);
+			}
+		};
+	};
+}

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -21,6 +21,11 @@ function RobustSockJS(){
 	this.connections = {};
 
 	var self = this;
+  // Robustify should just look up whether it exists, and deal with the matrix
+  // of whether it does/expected to exist
+  // THen once it finds a connection, it just returns the connection. Otherwise, it 
+  // new()s one.
+  // Robust is just an encapsulated abstraction for taking these underlying things.
 	this.robustify = function(conn){
     var m = /\/__sockjs__\/([no])=(\w+)\//.exec(conn.pathname);
 		if (!m || m.length < 3){
@@ -36,6 +41,9 @@ function RobustSockJS(){
 		var oldConn = null;
 		var robustConn = null;
 		if (self.connections[id]){
+      //FIXME: if the client is intending to create a new connection, but we already
+      // have this ID. What happens?
+
 			// This must be a reconnect. We might not yet know that the client
 			// was closed. So make the best effort to close the old one, and hot
 			// swap in the new one.
@@ -49,6 +57,9 @@ function RobustSockJS(){
       }
 
       // Copy various properties over
+      // FIXME: We're leaking too much of the underlying connection into the 
+      // upper abstraction here. We should only have a subset of documented methods
+      // that work. Getters for any property that could be used elsewhere.
       _.extend(robustConn, _.pick(conn, connectionProps));
 
 			robustConn.close = function(){
@@ -107,6 +118,8 @@ function RobustSockJS(){
         robustConn._withheld.events.push({arg: arguments});
         if (!robustConn._withheld.timer){
           robustConn._withheld.timer = setTimeout(function(){
+            // If time has passed, actually kill the connection by emitting the
+            // withheld events of close and/or end.
             var evt;
             while ((evt = robustConn._withheld.events.pop())){
               doEmit.apply(null, evt.arg);
@@ -114,7 +127,7 @@ function RobustSockJS(){
           }, 15 * 1000);
         }
 
-				// delete self.connections[id];
+				// FIXME: memory leak delete self.connections[id];
 			} else {
         doEmit.apply(null, arguments);
 			}

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -22,35 +22,62 @@ function RobustSockJS(){
 
 	var self = this;
 	this.robustify = function(conn){
-		var id = crypto.randomBytes(32).toString('hex')
-		conn._robustId = id;
+    var m = /\/__sockjs__\/i=(\w+)\//.exec(conn.pathname);
+		if (!m || m.length < 2){
+			logger.warn("Invalid sockjs URL.");
+			conn.close();
+			return conn;
+		}
+		var id = m[1];
 
-		if (conn.readyState === 1) {
-			conn.write('0|i|' + id);
+		var oldConn = null;
+		var robustConn = null;
+		if (self.connections[id]){
+			// This must be a reconnect. We might not yet know that the client
+			// was closed. So make the best effort to close the old one, and hot
+			// swap in the new one.
+			robustConn = self.connections[id];
+
+			// Ensure that the public methods we use are current.
+			robustConn.write = function(){
+				conn.write.apply(conn, arguments);
+			};
+			robustConn.close = function(){
+				conn.close.apply(conn, arguments);
+			};
+		
+			// Store a record of the old connection so we can close it.
+			oldConn = robustConn._originalConn;
 		} else {
-			console.log("Conn not ready");
+			// This is a new connection. Create a robustConn object.
+			robustConn = _.clone(conn);
+			robustConn._originalConn = conn;
 		}
 
 		// Copy the properties over to the new object so it looks more like 
 		// a WebSocket.
-		var robustConn = _.clone(conn, connectionProps);
-		robustConn._originalConn = conn;
 		
 		// Override the underlying connection's emit so we can echo.
 		var oldEmit = conn.emit;
 		conn.emit = function(type) {
-			var emitArgs = arguments;
 			if (type === 'end' || type === 'close'){
-				// FIXME: Hold back events
-				delete self.connections[id];
+				// FIXME: Emit eventually...
+				// delete self.connections[id];
 			} else {
+				robustConn.emit.apply(robustConn, arguments);
+				oldEmit.apply(conn, arguments);
 			}
-			robustConn.emit.apply(robustConn, arguments);
-			oldEmit.apply(conn, arguments);
 		};
-		
-		// Add to registry
-		self.connections[id] = robustConn;
+
+		if (oldConn){
+			// Assign, then close the old connection
+			logger.debug("Replaced and closing SockJS connection #" + id);
+			oldConn.close();
+		} else {
+			// Add to registry
+			logger.trace("Storing persistent connection with ID: " + id);
+			self.connections[id] = robustConn;
+		}
 
 		return robustConn;
 	};

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -36,6 +36,9 @@ function createServer(router, schedulerRegistry) {
   var robust = new RobustSockJS();
   sockjsServer.on('connection', function(conn) {
     var robustConn = robust.robustify(conn);
+    if (!robustConn){
+      return;
+    }
     onMultiplexConnect(robustConn);
   });
 

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -29,7 +29,7 @@ function createServer(router, schedulerRegistry) {
   var sockjsServer = sockjs.createServer({
     // TODO: make URL configurable
     sockjs_url: '//d1fxtkz8shb9d2.cloudfront.net/sockjs-0.3.min.js',
-    prefix: '.*/__sockjs__',
+    prefix: '.*/__sockjs__/i=\\w+',
 		log: function() {}
   });
 

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -29,7 +29,7 @@ function createServer(router, schedulerRegistry) {
   var sockjsServer = sockjs.createServer({
     // TODO: make URL configurable
     sockjs_url: '//d1fxtkz8shb9d2.cloudfront.net/sockjs-0.3.min.js',
-    prefix: '.*/__sockjs__/i=\\w+',
+    prefix: '.*/__sockjs__/[no]=\\w+',
 		log: function() {}
   });
 

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -35,8 +35,8 @@ function createServer(router, schedulerRegistry) {
 
   var robust = new RobustSockJS();
   sockjsServer.on('connection', function(conn) {
-    robust.robustify(conn);
-    onMultiplexConnect(conn);
+    var robustConn = robust.robustify(conn);
+    onMultiplexConnect(robustConn);
   });
 
   function onMultiplexConnect(conn){

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -18,6 +18,7 @@ var fsutil = require('../core/fsutil');
 var shutdown = require('../core/shutdown');
 var render = require('../core/render');
 var MultiplexSocket = require('./multiplex');
+var RobustSockJS = require('./robust-sockjs');
 
 exports.createServer = createServer;
 function createServer(router, schedulerRegistry) {
@@ -29,15 +30,21 @@ function createServer(router, schedulerRegistry) {
     // TODO: make URL configurable
     sockjs_url: '//d1fxtkz8shb9d2.cloudfront.net/sockjs-0.3.min.js',
     prefix: '.*/__sockjs__',
-    log: function() {}
+		log: function() {}
   });
 
+  var robust = new RobustSockJS();
   sockjsServer.on('connection', function(conn) {
+    robust.robustify(conn);
+    onMultiplexConnect(conn);
+  });
+
+  function onMultiplexConnect(conn){
     var msSocket = new MultiplexSocket(conn);
     msSocket.on('connection', function(mconn) {
       handleMultiplexChannel(mconn);
     });
-  });
+  }
 
   function handleMultiplexChannel(conn) {
     if (!conn) {

--- a/lib/router/config-router.js
+++ b/lib/router/config-router.js
@@ -109,7 +109,8 @@ function ConfigRouter(conf, schedulerRegistry) {
   if (conf.getValues('disable_websockets').val){
     this.disabledProtocols.push('websocket');
   }
-  
+
+  this.reconnect = !conf.getValues('disable_reconnect').enabled;
   this.$allowAppOverride = conf.getValues('allow_app_override').enabled;
   this.$templateDir = conf.getValues('template_dir').dir;
 

--- a/test/robust-sockjs.js
+++ b/test/robust-sockjs.js
@@ -1,0 +1,96 @@
+/*
+ * test/robust-sockjs.js
+ *
+ * Copyright (C) 2009-13 by RStudio, Inc.
+ *
+ * This program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+var RobustSockJS = require('../lib/proxy/robust-sockjs');
+var sinon = require('sinon');
+var should = require('should');
+var _ = require('underscore');
+
+describe('RobustSockJS', function(){
+  describe('#robustify', function(){
+    it('errors on invalid URL', function(){
+      var rsjs = new RobustSockJS();
+      var conn = {pathname: 'blah', close: sinon.spy(), write: sinon.spy()};
+      rsjs.robustify(conn);
+      should(conn.close.called);
+    });
+    it('handles all 4 cases properly', function(){
+      var rsjs = new RobustSockJS();
+      _.size(rsjs._connections).should.equal(0);
+
+      // Fresh connections work
+      var conn = {
+        pathname: '/__sockjs__/n=1234/', 
+        close: sinon.spy(), 
+        write: function(){}
+      };
+      var rob = rsjs.robustify(conn);
+      _.size(rsjs._connections).should.equal(1);
+
+      // ID collisions fail
+      var rob2 = rsjs.robustify(conn);
+      _.size(rsjs._connections).should.equal(1);
+      (rob2 === undefined).should.be.true;
+
+      // Reconnects succeed.
+      conn.pathname = conn.pathname.replace(/\/n=/, '/o=');
+      rob = rsjs.robustify(conn);
+      _.size(rsjs._connections).should.equal(1);
+      (rob === undefined).should.be.false;
+
+      // Reconnects of expired/invalid IDs fail.
+      conn.pathname = conn.pathname.replace(/1234/, 'abcd');
+      rob2 = rsjs.robustify(conn);
+      _.size(rsjs._connections).should.equal(1);
+      (rob2 === undefined).should.be.true;
+    });
+    it('buffers disconnects', function(){
+      var clock = sinon.useFakeTimers();
+      var rsjs = new RobustSockJS(1); //Timeout after 1 sec
+      var conn = {
+        pathname: '/__sockjs__/n=1234/', 
+        close: sinon.spy(), 
+        write: function(){},
+        emit: function(){}
+      };
+
+      rob = rsjs.robustify(conn);
+      _.size(rsjs._connections).should.equal(1);
+
+      conn.emit('close');
+      conn.emit('end');
+
+      clock.tick(500);
+
+      // Should still be available
+      _.size(rsjs._connections).should.equal(1);
+
+      // Reconnect
+      conn.pathname = conn.pathname.replace(/\/n=/, '/o=');
+      rsjs.robustify(conn);
+
+      clock.tick(750);
+
+      conn.emit('close');
+      conn.emit('end');
+
+      _.size(rsjs._connections).should.equal(1);
+
+      clock.tick(1250);
+
+      _.size(rsjs._connections).should.equal(0);
+
+      clock.restore();
+    });
+  });
+});


### PR DESCRIPTION
Behavior:

 - If `disable_reconnect true` is set in the config, then the behavior mimics what we have today, with the subtle exception that Shiny Server, instead of Shiny, is producing the grey screen on disconnect (with slightly different mechanics). By default, the feature is enabled, though.
 - If we have an unexpected disconnect, we'll present they grey screen with a dialog at the top counting down from 15 seconds. The R session will stay active for this same amount of time. If the user clicks "reconnect" within those 15 seconds, they'll be reattached to their original session with no lost state.
 - After 15 seconds with no user intervention, we'll close the connection to the Shiny process, and the UI will no longer offer to "reconnect" but rather will say that you've been disconnected and the button will say "Reload", which just refreshes the page and starts a new session.
 - If we reconnect to a server who has no knowledge of the ID we provide (i.e. if the server was restarted), then we'll immediately get an alert explaining that our session has been lost and we'll see the "Reload" button.
 - If disconnected cleanly (i.e. the server or client called a `conn.close()`) then we immediately present the "Reload" option, skipping over the whole "reconnect" business.

Feedback on dialog UI and text especially welcome.

CC @jcheng5 @aronatkins 

P.S. My editor was doing weird things with the JS. I may do a grant re-indent before I merge, but I didn't want to confuse the diff.