### PR TITLE
Jeff/clear reconnect

### DIFF
--- a/assets/shiny-server.css
+++ b/assets/shiny-server.css
@@ -17,6 +17,11 @@ body.disconnected {
   left: 30%;
   right: 30%;
   z-index: 99999;
+  border: 1px solid #888;
+  border-top: none;
+  border-radius: 0 0 7px 7px;
+  background-color: #F6F6F6;
+  box-shadow: 2px 2px 8px #777;
 }
 
 .ss-dialog-button {
@@ -26,16 +31,21 @@ body.disconnected {
 .ss-dialog-text {
 }
 
-#ss-gray-out {
+#ss-overlay {
   position: fixed;
   top: 0;
   left: 0;
   bottom: 0;
   right: 0;
-  background-color: #999;
-  opacity: 0.7;
   z-index: 99998;
   overflow: hidden;
+  cursor: progress;
+}
+
+.ss-gray-out {
+  background-color: #999;
+  opacity: 0.7;
+  cursor: not-allowed !important;
 }
 
 #ss-clearfix {

--- a/assets/shiny-server.css
+++ b/assets/shiny-server.css
@@ -10,7 +10,7 @@ body.disconnected {
 
 #ss-connect-dialog {
   opacity: 1 !important;
-  padding: .5em 1em 1em 1em;
+  padding: 1em;
   background-color: #FFF;
   position: fixed;
   top: 0;

--- a/assets/shiny-server.js
+++ b/assets/shiny-server.js
@@ -338,7 +338,7 @@
       self._disconnectTimer = setTimeout(function(){
         debug('Displaying disconnect screen.');
         $('body').addClass('ss-reconnecting');
-        $('<div id="ss-connect-dialog">'+dialogMsg+'<div class="ss-clearfix"></div></div><div id="ss-gray-out"></div>').appendTo('body');
+        $('<div id="ss-connect-dialog">'+dialogMsg+'<div class="ss-clearfix"></div></div><div id="ss-overlay"></div>').appendTo('body');
       }, 3500);
 
       var timeout = 15;
@@ -445,7 +445,8 @@
             // We were not able to reconnect
             self._doClose();
             $('body').removeClass('ss-reconnecting');
-            $('#ss-connect-dialog').html('<button id="ss-reload-button" type="button" class="ss-dialog-button">Reload</button> Disconnected from the server.');
+            $('#ss-overlay').addClass('ss-gray-out');
+            setReconnectDialog('<button id="ss-reload-button" type="button" class="ss-dialog-button">Reload</button> Disconnected from the server.');
             $('#ss-reload-button').click(function(){
               location.reload();
             });
@@ -466,7 +467,7 @@
         self.startReconnect();
       } else {
         self._doClose();
-        $('<div id="ss-gray-out"></div>').appendTo('body');
+        $('<div class="ss-gray-out"></div>').appendTo('body');
       }
     };
 


### PR DESCRIPTION
Adds a clear overlay during reconnect to avoid visual gray-out, but does change the cursor to show that it's "thinking" and prohibits further user interaction with the mouse. On disconnect, change the cursor again and gray out.