### PR TITLE
Don't forbid storage of templated files.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -184,7 +184,7 @@ app.use(connect_util.filterByRegex(
       res.setHeader('Content-Type', 'application/javascript');
 
       // Disable cache so server-side updates to available protocols show immediately.
-      res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+      res.setHeader('Cache-Control', 'no-cache, must-revalidate');
       res.setHeader('Pragma', 'no-cache');
       res.setHeader('Expires', '0');
 


### PR DESCRIPTION
no-cache is sufficient to discourage browsers from serving the
cached version of a file. With browser history and/or tab
reopening, however, the browser /will/ use the cached version of the
file (tested on Chrome and Firefox). Thus, if a file is essential in
order to reload the state of a tab (as is the case for the templated
shiny-server.js), you need to allow the browser to store so that it
will have a copy of shiny-server.js when it re-opens the tab.

This commit restores the "disconnect" dialog box when reopening a closed
tab while offline.