### PR TITLE
Don't proxy connections through robustification

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -244,8 +244,10 @@ var loadConfig_p = qutil.serialized(function() {
     schedulerRegistry.setTransport(transport);
     transport.setSocketDir(configRouter.socketDir);
     
+    var reconnect = configRouter.reconnect;
+    
     // Create SockJS server
-    sockjsServer = proxy_sockjs.createServer(metarouter, schedulerRegistry);
+    sockjsServer = proxy_sockjs.createServer(metarouter, schedulerRegistry, reconnect);
     sockjsHandler = sockjsServer.middleware();
 
     // Set the available protocols
@@ -263,8 +265,6 @@ var loadConfig_p = qutil.serialized(function() {
       logger.info("Disabled protocols: " + configRouter.disabledProtocols.join(","));
     }
     
-    var reconnect = configRouter.reconnect;
-
     renderedSSJS = renderSSJS(prots, reconnect);
 
     return createLogger_p(configRouter.accessLogSpec)

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -21,7 +21,7 @@ var MultiplexSocket = require('./multiplex');
 var RobustSockJS = require('./robust-sockjs');
 
 exports.createServer = createServer;
-function createServer(router, schedulerRegistry) {
+function createServer(router, schedulerRegistry, reconnect) {
   // Create a single SockJS server that will serve all applications. We'll use
   // the connection.url to dispatch among the different worker processes'
   // websocket ports. Once a connection is established, we simply pipe IO
@@ -35,11 +35,19 @@ function createServer(router, schedulerRegistry) {
 
   var robust = new RobustSockJS();
   sockjsServer.on('connection', function(conn) {
-    var robustConn = robust.robustify(conn);
-    if (!robustConn){
-      return;
+    if (reconnect){
+      var robustConn = robust.robustify(conn);
+      if (!robustConn){
+        return;
+      }
+      onMultiplexConnect(robustConn);
+    } else {
+      // Extend the conn object with a getter we use in robust connections
+      conn.getReadyState = function(){
+        return conn.readyState;
+      };
+      onMultiplexConnect(conn);
     }
-    onMultiplexConnect(robustConn);
   });
 
   function onMultiplexConnect(conn){


### PR DESCRIPTION
If reconnects are disabled, don't even use the RobustSockJS server.
Send the connection directly to the multiplexer like we used to so that
the robustification feature is completely disabled.