### PR TITLE
Use upstart for server management under Mint Linux

### DIFF
--- a/packaging/debian-control/postinst.in
+++ b/packaging/debian-control/postinst.in
@@ -83,7 +83,7 @@ then
    systemctl enable shiny-server.service
    systemctl start shiny-server.service
    systemctl --no-pager status shiny-server.service
-elif test $LSB_RELEASE = "Ubuntu" && test -d /etc/init/
+elif (test $LSB_RELEASE = "Ubuntu" || test $LSB_RELEASE = "LinuxMint") && test -d /etc/init/
 then
    cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/upstart/shiny-server.conf /etc/init/
 

--- a/packaging/debian-control/prerm.in
+++ b/packaging/debian-control/prerm.in
@@ -14,7 +14,7 @@ then
     systemctl daemon-reload
     rm -f /etc/systemd/system/shiny-server.service
 
-elif test $LSB_RELEASE = "Ubuntu" && test -d /etc/init/
+elif (test $LSB_RELEASE = "Ubuntu" || test $LSB_RELEASE = "LinuxMint") && test -d /etc/init/
 then
     initctl stop shiny-server 2>/dev/null
     rm -r /etc/init/shiny-server.conf


### PR DESCRIPTION
Debian package didn't install /etc/init/shiny-server.conf due to failed test for system id. A test for system id of "LinuxMint" should fix this. I checked the test statements, but did not test the installer.