### PR TITLE
Fix robust-sockjs tests

### DIFF
--- a/test/robust-sockjs.js
+++ b/test/robust-sockjs.js
@@ -18,11 +18,11 @@ var _ = require('underscore');
 
 describe('RobustSockJS', function(){
   describe('#robustify', function(){
-    it('errors on invalid URL', function(){
+    it('no-ops on non-robust URL', function(){
       var rsjs = new RobustSockJS();
-      var conn = {pathname: 'blah', close: sinon.spy(), write: sinon.spy()};
-      rsjs.robustify(conn);
-      should(conn.close.called);
+      var conn = {url: 'blah', close: sinon.spy(), write: sinon.spy()};
+      var result = rsjs.robustify(conn);
+      should(conn === result);
     });
     it('handles all 4 cases properly', function(){
       var rsjs = new RobustSockJS();
@@ -30,8 +30,8 @@ describe('RobustSockJS', function(){
 
       // Fresh connections work
       var conn = {
-        pathname: '/__sockjs__/n=1234/', 
-        close: sinon.spy(), 
+        url: '/__sockjs__/n=1234/',
+        close: sinon.spy(),
         write: function(){}
       };
       var rob = rsjs.robustify(conn);
@@ -43,13 +43,13 @@ describe('RobustSockJS', function(){
       (rob2 === undefined).should.be.true;
 
       // Reconnects succeed.
-      conn.pathname = conn.pathname.replace(/\/n=/, '/o=');
+      conn.url = conn.url.replace(/\/n=/, '/o=');
       rob = rsjs.robustify(conn);
       _.size(rsjs._connections).should.equal(1);
       (rob === undefined).should.be.false;
 
       // Reconnects of expired/invalid IDs fail.
-      conn.pathname = conn.pathname.replace(/1234/, 'abcd');
+      conn.url = conn.url.replace(/1234/, 'abcd');
       rob2 = rsjs.robustify(conn);
       _.size(rsjs._connections).should.equal(1);
       (rob2 === undefined).should.be.true;
@@ -58,8 +58,8 @@ describe('RobustSockJS', function(){
       var clock = sinon.useFakeTimers();
       var rsjs = new RobustSockJS(1); //Timeout after 1 sec
       var conn = {
-        pathname: '/__sockjs__/n=1234/', 
-        close: sinon.spy(), 
+        url: '/__sockjs__/n=1234/',
+        close: sinon.spy(),
         write: function(){},
         emit: function(){}
       };
@@ -76,7 +76,7 @@ describe('RobustSockJS', function(){
       _.size(rsjs._connections).should.equal(1);
 
       // Reconnect
-      conn.pathname = conn.pathname.replace(/\/n=/, '/o=');
+      conn.url = conn.url.replace(/\/n=/, '/o=');
       rsjs.robustify(conn);
 
       clock.tick(750);


### PR DESCRIPTION
cc @trestletech 

(Sorry, I didn't even know we had automated tests for this stuff)

- robustify() semantics had slightly changed; we now send connections
  through that method whether we think they are robust or not, and
  non-robust connections are unchanged instead of closed.
- The tests assumed that the .pathname property was used to find
  URL parameters, actually it is .url.