### PR TITLE
Enabling error hiding option through config file

### DIFF
--- a/R/SockJSAdapter.R
+++ b/R/SockJSAdapter.R
@@ -32,6 +32,7 @@ local({
     disableProtocols <- paste('"', disableProtocols, '"', sep = '', collapse = ',')
   }
   reconnect <- if (identical("true", tolower(input[11]))) "true" else "false"
+  options(shiny.sanitize.errors = identical("true", tolower(input[12])))
 
   close(fd)
 

--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -204,7 +204,7 @@ reconnect {
 }
 
 sanitize_errors {
-  desc "If this setting is true (the default), only generic error messages will be shown to the client (unless these were produced by `customStop()`).";
+  desc "If this setting is true (the default), only generic error messages will be shown to the client (unless these were wrapped in `safeError()`).";
   param Boolean [enabled] "Whether or not to sanitize error messages on the client." true;
   at $ server location;
   maxcount 1;

--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -202,3 +202,10 @@ reconnect {
   at $ server location;
   maxcount 1;
 }
+
+sanitize_errors {
+  desc "If this setting is true (the default), only generic error messages will be shown to the client (unless these were produced by `customStop()`).";
+  param Boolean [enabled] "Whether or not to sanitize error messages on the client." true;
+  at $ server location;
+  maxcount 1;
+}

--- a/lib/proxy/http.js
+++ b/lib/proxy/http.js
@@ -26,7 +26,7 @@ var error404 = render.error404;
 var errorAppOverloaded = render.errorAppOverloaded;
 
 // Send a 500 error response
-function error500(req, res, errorText, detail, templateDir, consoleLogFile) {
+function error500(req, res, errorText, detail, templateDir, consoleLogFile, appSpec) {
   fsutil.safeTail_p(consoleLogFile, 8192)
   .fail(function(consoleLog) {
     return;
@@ -38,7 +38,7 @@ function error500(req, res, errorText, detail, templateDir, consoleLogFile) {
       vars: {
         message: errorText,
         detail: detail,
-        console: consoleLog
+        console: (appSpec && appSpec.settings.appDefaults.sanitizeErrors) ? null : consoleLog
       }
     });
   })
@@ -170,7 +170,7 @@ function ShinyProxy(router, schedulerRegistry) {
         req.on('error', function(err) {
           logger.error('Error during proxy: ' + err.message);
           error500(req, res, 'An error occurred while transferring data from the application.',
-              err.message, appSpec.settings.templateDir, appWorkerHandle.logFilePath);
+              err.message, appSpec.settings.templateDir, appWorkerHandle.logFilePath, appSpec);
         });
 
         logger.trace('Proxying request: ' + req.url);
@@ -188,7 +188,7 @@ function ShinyProxy(router, schedulerRegistry) {
           error404(req, res, appSpec.settings.templateDir);
         else {
           error500(req, res, 'The application failed to start.', err.message,
-              appSpec.settings.templateDir, err.consoleLogFile);
+              appSpec.settings.templateDir, err.consoleLogFile, appSpec);
         }
       })
       .done();
@@ -247,7 +247,7 @@ function ShinyProxy(router, schedulerRegistry) {
       // This happens when an error occurs during request proxying, for example
       // if the upstream server drops the connection.
       error500(req, res, 'The application exited unexpectedly.', err.message,
-          req.templateDir, appWorkerHandle.logFilePath);
+          req.templateDir, appWorkerHandle.logFilePath, appWorkerHandle.appSpec);
       cleanupResponse(res);
     });
     proxy.on('end', function(req, res) {

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -9,7 +9,9 @@
  * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
- */
+ */ 
+
+ // change
 var pause = require('pause');
 var sockjs = require('sockjs');
 var OutOfCapacityError = require('../core/errors').OutOfCapacity;
@@ -183,17 +185,29 @@ function createServer(router, schedulerRegistry) {
         // is an unexpected close (i.e. the R process terminated).
         fsutil.safeTail_p(appWorkerHandle.logFilePath, 8192)
         .fail(function(consoleLog) {
+          //console.log('got here');
           return '';
         })
         .then(function(consoleLog) {
-          render.sendClientConsoleMessage(conn, consoleLog);
-          var moreInfo = consoleLog
+          var moreInfo = "hello";
+          //console.log(appSpec.settings.appDefaults.sanitizeErrors);
+          if (appSpec.settings.appDefaults.sanitizeErrors) {
+            //console.log("sanitizeErrors is true");
+            moreInfo = consoleLog
+              ? "\r\n\r\nDiagnostic information is private. Please ask your system admin for" +
+              "permission if you need to check the R logs."
+              : "";
+          } else {
+            render.sendClientConsoleMessage(conn, consoleLog);
+            //console.log("sanitizeErrors is false");
+            moreInfo = consoleLog
               ? "\r\n\r\nDiagnostic information has been dumped to the JavaScript error console."
               : "";
-
+          }
           var exitMessage = shutdown.shuttingDown ?
               'The server is restarting.\r\n\r\nPlease wait a few moments, then refresh the page.' :
               'The application unexpectedly exited.' + moreInfo;
+          //console.log(moreInfo);
           render.sendClientAlertMessage(conn, exitMessage);
         })
         .fail(function(err) {

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -10,8 +10,6 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */ 
-
- // change
 var pause = require('pause');
 var sockjs = require('sockjs');
 var OutOfCapacityError = require('../core/errors').OutOfCapacity;
@@ -185,29 +183,23 @@ function createServer(router, schedulerRegistry) {
         // is an unexpected close (i.e. the R process terminated).
         fsutil.safeTail_p(appWorkerHandle.logFilePath, 8192)
         .fail(function(consoleLog) {
-          //console.log('got here');
           return '';
         })
         .then(function(consoleLog) {
-          var moreInfo = "hello";
-          //console.log(appSpec.settings.appDefaults.sanitizeErrors);
           if (appSpec.settings.appDefaults.sanitizeErrors) {
-            //console.log("sanitizeErrors is true");
-            moreInfo = consoleLog
+            var moreInfo = consoleLog
               ? "\r\n\r\nDiagnostic information is private. Please ask your system admin for" +
               "permission if you need to check the R logs."
               : "";
           } else {
             render.sendClientConsoleMessage(conn, consoleLog);
-            //console.log("sanitizeErrors is false");
-            moreInfo = consoleLog
+            var moreInfo = consoleLog
               ? "\r\n\r\nDiagnostic information has been dumped to the JavaScript error console."
               : "";
           }
           var exitMessage = shutdown.shuttingDown ?
               'The server is restarting.\r\n\r\nPlease wait a few moments, then refresh the page.' :
               'The application unexpectedly exited.' + moreInfo;
-          //console.log(moreInfo);
           render.sendClientAlertMessage(conn, exitMessage);
         })
         .fail(function(err) {

--- a/lib/router/config-router-util.js
+++ b/lib/router/config-router-util.js
@@ -49,6 +49,7 @@ function parseApplication(settings, locNode, provideDefaults){
     appSettings.idleTimeout = 5;
     appSettings.preserveLogs = false;
     appSettings.reconnect = true;
+    appSettings.sanitizeErrors = true;
     appSettings.disableProtocols = [];
   }
 
@@ -70,6 +71,11 @@ function parseApplication(settings, locNode, provideDefaults){
   if (locNode.getOne('reconnect') &&
       locNode.getValues('reconnect').enabled === false) {
     appSettings.reconnect = false;
+  }
+
+  if (locNode.getOne('sanitize_errors') &&
+      locNode.getValues('sanitize_errors').enabled === false) {
+    appSettings.sanitizeErrors = false;
   }
 
   var disableProtocolsNode = locNode.getOne('disable_protocols', true);

--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -265,7 +265,8 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
         paths.projectFile('ext/pandoc') + '\n' +
         logFile + '\n' +
         appSpec.settings.appDefaults.disableProtocols.join(",") + '\n' +
-        appSpec.settings.appDefaults.reconnect + '\n'
+        appSpec.settings.appDefaults.reconnect + '\n' +
+        appSpec.settings.appDefaults.sanitizeErrors + '\n'
       );
       self.$proc.stdout.pipe(split()).on('data', function(line){
         var match = null;

--- a/node_modules/sockjs/node_modules/.bin/uuid
+++ b/node_modules/sockjs/node_modules/.bin/uuid
@@ -1,0 +1,1 @@
+../node-uuid/bin/uuid

--- a/vagrant/ubuntu14.04/Vagrantfile
+++ b/vagrant/ubuntu14.04/Vagrantfile
@@ -51,7 +51,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
   config.vm.synced_folder "../../", "/shiny-server"
-  config.vm.synced_folder "/Users/barbaraborges/RStudio/error-hiding-demo", "/srv/shiny-server"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/vagrant/ubuntu14.04/Vagrantfile
+++ b/vagrant/ubuntu14.04/Vagrantfile
@@ -50,6 +50,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder "../../", "/shiny-server"
+  config.vm.synced_folder "/Users/barbaraborges/RStudio/error-hiding-demo", "/srv/shiny-server"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
There's an [outstanding shiny PR](https://github.com/rstudio/shiny/pull/1156) right now that adds a shiny option to sanitize the errors that appear in the UI/app itself (the default is sanitized errors: `options(shiny.sanitize.errors = TRUE)`). This leaves the console logs unchanged but now to see these, you need to either have access to the console (like in local development) or to the console logs stored in shiny server. This decreases security risks -- no chance of some sensitive information leaking through to the end user via an error message. 

This PR enables the system admins for shiny server to set `shiny.sanitize.errors` according to their needs. The default is sanitized errors, but if people are not worried about security, they can override this by adding `sanitize_errors false` to the config file (which might make debugging a little easier -- the user doesn't have to go digging through the logs to find the bugs). This option controls three things. If `true`:

- it replaces all UI error messages by a generic message: "An error has occurred. Check your logs or contact the app author for clarification."

- if the app or the server crash, it prevents the R console from being dumped into the JS console.

- if there is an error in an R file (e.g. `SockJSAdapater.R`, `ui.R`, `global.R`), it prevents the R console from being displayed in the app.
