### PR TITLE
Updated the config-router-util to work with 'disable_websockets true;'

### DIFF
--- a/lib/router/config-router-util.js
+++ b/lib/router/config-router-util.js
@@ -89,7 +89,7 @@ function parseApplication(settings, locNode, provideDefaults){
     });
   }
   if (locNode.getValues('disable_websockets').val){
-    appSettings.disableProtocols.disabledProtocols.push('websocket');
+    appSettings.disableProtocols.push('websocket');
   }
 
   settings.appDefaults = appSettings;


### PR DESCRIPTION
Fixes #229.
Updated the config-router-util to work correctly when the 'disable_websockets true;' is set in the shiny-server.conf.

The current implementation throws this error:

```[ERROR] shiny-server - Error loading config: Cannot call method 'push' of undefined```