### PR TITLE
Use correct bookmarking directory

### DIFF
--- a/R/SockJSAdapter.R
+++ b/R/SockJSAdapter.R
@@ -34,13 +34,22 @@ local({
   reconnect <- if (identical("true", tolower(input[11]))) "true" else "false"
   options(shiny.sanitize.errors = identical("true", tolower(input[12])))
 
+  # Top-level bookmarking directory (for all users)
   bookmarkStateDir <- tolower(input[13])
+  # Name of bookmark directory for this app. Uses the basename of the path and
+  # appends a hash of the full path. So if the path is "/path/to/myApp", the
+  # result is "myApp-6fbdbedc4c99d052b538b2bfc3c96550".
+  bookmarkAppDir <- paste0(
+    basename(input[1]), "-",
+    digest::digest(input[1], algo = "md5", serialize = FALSE)
+  )
+
   if (!is.null(asNamespace("shiny")$shinyOptions)) {
     if (nchar(bookmarkStateDir) > 0) {
       shiny::shinyOptions(
         save.interface = function(id, callback) {
           username <- Sys.info()[["effective_user"]]
-          dirname <- file.path(bookmarkStateDir, username, id)
+          dirname <- file.path(bookmarkStateDir, username, bookmarkAppDir, id)
           if (dir.exists(dirname)) {
             stop("Directory ", dirname, " already exists")
           } else {


### PR DESCRIPTION
Previously the path used for bookmarking was not separated per app. For example, it would put files in:

```
/var/lib/shiny-server/bookmarks/shiny/76460940f1cd9dfb
```

Instead of the intended destination:
```
/var/lib/shiny-server/bookmarks/shiny/myApp-6fbdbedc4c99d052b538b2bfc3c96550/76460940f1cd9dfb
```

This pull request corrects that.