### PR TITLE
Create application's bookmark state directory only when needed

### DIFF
--- a/R/SockJSAdapter.R
+++ b/R/SockJSAdapter.R
@@ -59,7 +59,7 @@ local({
         },
         load.interface = function(id, callback) {
           username <- Sys.info()[["effective_user"]]
-          dirname <- file.path(bookmarkStateDir, username, id)
+          dirname <- file.path(bookmarkStateDir, username, bookmarkAppDir, id)
           if (!dir.exists(dirname)) {
             stop("Session ", id, " not found")
           } else {

--- a/R/SockJSAdapter.R
+++ b/R/SockJSAdapter.R
@@ -53,7 +53,7 @@ local({
           if (dir.exists(dirname)) {
             stop("Directory ", dirname, " already exists")
           } else {
-            dir.create(dirname, recursive = FALSE, mode = "0700")
+            dir.create(dirname, recursive = TRUE, mode = "0700")
             callback(dirname)
           }
         },

--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -31,7 +31,6 @@ var paths = require('../core/paths');
 var permissions = require('../core/permissions');
 var split = require('split');
 var posix = require('../../build/Release/posix');
-var crypto = require('crypto');
 
 var rprog = process.env.R || 'R';
 var scriptPath = paths.projectFile('R/SockJSAdapter.R');
@@ -162,7 +161,7 @@ exports.runWorker_p = runWorker_p;
  * Creates the top-level (system) bookmark state directory, then the user's
  * bookmark state directory, and then the app's bookmark state directory.
  */
-function createBookmarkStateDirectory_p(bookmarkStateDir, username, appdir) {
+function createBookmarkStateDirectory_p(bookmarkStateDir, username) {
   if (bookmarkStateDir === null || bookmarkStateDir === "") {
     return Q();
   }
@@ -212,14 +211,10 @@ function createBookmarkStateDirectory_p(bookmarkStateDir, username, appdir) {
   }
 
   var userBookmarkStateDir = path.join(bookmarkStateDir, username);
-  var appBookmarkStateDir = path.join(userBookmarkStateDir, appdir);
 
   return createDir_p(bookmarkStateDir, '711')
   .then(function() {
-    createDir_p(userBookmarkStateDir, '700', username, 'user')
-    .then(function() {
-      createDir_p(appBookmarkStateDir, '700', username, 'app');
-    });
+    createDir_p(userBookmarkStateDir, '700', username, 'user');
   })
   .fail(function(err) {
     throw err;
@@ -308,12 +303,9 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
           appSpec.appDir);
       }
 
-      var appDirHash = crypto.createHash('md5').update(appSpec.appDir).digest('hex');
-
       return createBookmarkStateDirectory_p(
         appSpec.settings.appDefaults.bookmarkStateDir,
-        appSpec.runAs,
-        path.basename(appSpec.appDir + '-' + appDirHash)
+        appSpec.runAs
       );
     })
     .then(function() {


### PR DESCRIPTION
Previously, each application would have its bookmark state directory created on startup, even if it wasn't needed. Now the application's bookmark directory is created only when bookmarking is actually attempted.

This PR also fixes a bug where it attempted to restore bookmarks from the wrong directory. Not sure how I missed that in testing before. :(