### PR TITLE
Don't return reused connection from robustify()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+shiny-server 1.4.7
+--------------------------------------------------------------------------------
+
+* Fix a minor bug where subapps being created after a disrupted-then-restored
+  SockJS connection, might result in a duplicate connection.
+
 shiny-server 1.4.6
 --------------------------------------------------------------------------------
 (Skipped 1.4.5 for parity with Shiny Server Pro; 1.4.5 was a security release

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -78,6 +78,8 @@ function RobustSockJSRegistry(timeout){
         logger.debug("Reconnecting to robust connection: " + id);
 
         self._connections[id].set(conn);
+        // Return falsey as no further processing/wiring is needed on this connection.
+        return;
       } else {
         // Trying to create a new session with a colliding ID
         logger.warn("RobustSockJS collision: " + id);

--- a/test/robust-sockjs.js
+++ b/test/robust-sockjs.js
@@ -47,8 +47,7 @@ describe('RobustSockJS', function(){
       conn.url = conn.url.replace(/\/n=/, '/o=');
       var rob3 = rsjs.robustify(conn);
       _.size(rsjs._connections).should.equal(1);
-      (rob3 === undefined).should.be.false;
-      (rob3 === rob).should.be.true;
+      (rob3 === undefined).should.be.true;
 
       // Reconnects of expired/invalid IDs fail.
       conn.url = conn.url.replace(/1234/, 'abcd');


### PR DESCRIPTION
(This is a change that was in shiny-server-pro since January.)

When a reconnection occurs, there's no need in lib/proxy/sockjs.js
to call onMultiplexConnect; that logic has already been called on
the robustConn object, the first time it was returned from robustify.

It turns out that most times this doesn't make a difference, maybe
because it's unlikely after a reconnect for another multiplex
channel to connect itself (i.e. a new subapp appears); most Shiny
apps either don't have subapps, or only load subapps during startup.
Otherwise I think it's likely we would have seen handleMultiplexChannel
called multiple times on a single channel.

Here's a sample app that will demonstrate the bad behavior. Start
shiny-server with SHINY_LOG_LEVEL=TRACE; load the app in a browser;
in the JS console, run \__shinyserverdebug__.disconnect(); then hit
the Go button. Without this fix, each time you hit Go, you'll see the
number of websocket connections go up by *two*, not one. With this
fix, you'll see that the number of connections just goes up by one.
The problem is more than just too many connections being used. If
the actions of the subapp have side effects, you may actually get
incorrect results. Granted we are talking about a severe edge case
of an edge case, but it's theoretically possible.

```
library(shiny)

ui <- fluidPage(
  actionButton("go", "Go"),
  uiOutput("ui")
)

server <- function(input, output, session) {
  output$ui <- renderUI({
    req(input$go)
    htmltools::as.tags(shinyAppDir(system.file("examples/01_hello", package="shiny")))
  })
}

shinyApp(ui, server)
```