### PR TITLE
Upgrade shiny-server-client

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -322,8 +322,8 @@
     },
     "shiny-server-client": {
       "version": "1.0.0",
-      "from": "https://github.com/rstudio/shiny-server-client/archive/33ef43e.tar.gz",
-      "resolved": "https://github.com/rstudio/shiny-server-client/archive/33ef43e.tar.gz",
+      "from": "https://github.com/rstudio/shiny-server-client/archive/803ebb14.tar.gz",
+      "resolved": "https://github.com/rstudio/shiny-server-client/archive/803ebb14.tar.gz",
       "dependencies": {
         "pinkyswear": {
           "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/rstudio/shiny-server.git"
   },
   "dependencies" : {
-    "shiny-server-client" :  "https://github.com/rstudio/shiny-server-client/archive/33ef43e.tar.gz",
+    "shiny-server-client" :  "https://github.com/rstudio/shiny-server-client/archive/803ebb14.tar.gz",
     "faye-websocket"    :  "https://github.com/rstudio/faye-websocket-node/archive/95436354.tar.gz",
     "http-proxy"        :  "https://github.com/rstudio/node-http-proxy/archive/039f907.tar.gz",
     "sockjs"            :  "0.3.15",


### PR DESCRIPTION
This upgrade fixes a regression where the protocol chooser UI
shows all protocols, regardless of whether the server has them
enabled or not.

Older versions of SS/SSP hide the protocols that are disabled.
Versions that used prior versions of shiny-server-client show
all the protocols. This change still shows all the protocols,
but now greys out the ones that are not enabled by the server.