### PR TITLE
Replace (missing) express logger with morgan

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -20,6 +20,7 @@ var url = require('url');
 var util = require('util');
 var client_sessions = require('client-sessions');
 var express = require('express');
+var morgan = require('morgan');
 var optimist = require('optimist');
 var Q = require('q');
 var _ = require('underscore');
@@ -256,7 +257,11 @@ function createLogger_p(logSpec) {
   try {
     var stream = fs.createWriteStream(logSpec.path, {flags: 'a'});
     var next = function(){};
-    var log = connect.logger({stream: stream, format: logSpec.format});
+    var format = logSpec.format;
+    if (format === "default") {
+      format = "combined";  // "default" is deprecated in morgan
+    }
+    var log = morgan(format, {stream: stream});
     return Q.resolve(function(req, res) {
       log(req, res, next);
     });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -37,6 +37,11 @@
       "from": "https://registry.npmjs.org/bash/-/bash-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/bash/-/bash-0.0.1.tgz"
     },
+    "basic-auth": {
+      "version": "1.0.4",
+      "from": "basic-auth@>=1.0.3 <1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz"
+    },
     "brace-expansion": {
       "version": "1.1.6",
       "from": "brace-expansion@>=1.0.0 <2.0.0",
@@ -50,27 +55,31 @@
     "camelcase": {
       "version": "1.2.1",
       "from": "camelcase@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "optional": true
     },
     "center-align": {
       "version": "0.1.3",
       "from": "center-align@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "optional": true
     },
     "client-sessions": {
       "version": "0.7.0",
-      "from": "client-sessions@>=0.7.0 <0.8.0",
+      "from": "https://registry.npmjs.org/client-sessions/-/client-sessions-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/client-sessions/-/client-sessions-0.7.0.tgz"
     },
     "cliui": {
       "version": "2.1.0",
       "from": "cliui@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "optional": true,
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
           "from": "wordwrap@0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "optional": true
         }
       }
     },
@@ -122,7 +131,8 @@
     "decamelize": {
       "version": "1.2.0",
       "from": "decamelize@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "optional": true
     },
     "depd": {
       "version": "1.1.0",
@@ -183,7 +193,7 @@
     },
     "faye-websocket": {
       "version": "0.11.0",
-      "from": "faye-websocket@>=0.11.0 <0.12.0",
+      "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz"
     },
     "finalhandler": {
@@ -301,7 +311,8 @@
     "lazy-cache": {
       "version": "1.0.4",
       "from": "lazy-cache@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "optional": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -425,6 +436,11 @@
       "from": "moment@>=2.15.0 <2.16.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
     },
+    "morgan": {
+      "version": "1.7.0",
+      "from": "morgan@latest",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz"
+    },
     "ms": {
       "version": "0.7.1",
       "from": "ms@0.7.1",
@@ -439,6 +455,11 @@
       "version": "2.3.0",
       "from": "on-finished@>=2.3.0 <2.4.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "from": "on-headers@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
     },
     "once": {
       "version": "1.4.0",
@@ -497,7 +518,7 @@
     },
     "regexp-quote": {
       "version": "0.0.0",
-      "from": "regexp-quote@0.0.0",
+      "from": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz"
     },
     "repeat-string": {
@@ -518,7 +539,8 @@
     "right-align": {
       "version": "0.1.3",
       "from": "right-align@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "optional": true
     },
     "samsam": {
       "version": "1.1.2",
@@ -777,23 +799,27 @@
       "version": "2.7.3",
       "from": "uglify-js@>=2.6.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
+      "optional": true,
       "dependencies": {
         "async": {
           "version": "0.2.10",
           "from": "async@>=0.2.6 <0.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "optional": true
         },
         "source-map": {
           "version": "0.5.6",
           "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "optional": true
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
       "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "optional": true
     },
     "underscore": {
       "version": "1.8.3",
@@ -850,7 +876,8 @@
     "window-size": {
       "version": "0.1.0",
       "from": "window-size@0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "optional": true
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -865,7 +892,8 @@
     "yargs": {
       "version": "3.10.0",
       "from": "yargs@>=3.10.0 <3.11.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "log4js": "0.6.x",
     "mocha": "3.1.x",
     "moment": "2.15.x",
+    "morgan": "^1.7.0",
     "optimist": "0.6.1",
     "pause": "0.1.0",
     "q": "1.4.x",


### PR DESCRIPTION
Fixes the crashing error when access_log directive is used.