### PR TITLE
Allow whitelisted HTTP headers to pass through to shiny apps

### DIFF
--- a/config.html
+++ b/config.html
@@ -2,11 +2,9 @@
     <p><strong>Applies to</strong> indicates the kind of parent scope that this directive normally appears inside.</p>
     <p><strong>Inheritable</strong> means that you can put this directive at a higher level in the hierarchy and it will be inherited by any children to which it might apply. Inherited directives can be overridden by using the directive again in a child scope.</p>
     <ul class="directives">
-      
         <li>
           <h3 class="code"><a name="run_as"></a>run_as</h3>
           <p class="desc">The user the app should be run as. This user should have the minimal amount of privileges necessary to successfully run the application (i.e. read-only access to the Shiny application directory). Note that this directive cannot be used with <a class="code" href="#user_apps">user_apps</a>, as <code>user_apps</code> always run as the user who owns the application.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -22,7 +20,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>users</td>
                   <td>String</td>
@@ -30,21 +27,16 @@
                   <td>The username that should be used to run the app. If using home_dirs, this can also be the special keyword <code>:HOME_USER:</code> which will instruct <code>home_dirs</code> to run as the user in whose home directory the application exists. If using a special keyword like <code>:HOME_USER:</code>, you can specify additional usernames afterwards which will be used when this directive is applied to hosting models other than <code>home_dirs</code>.</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="access_log"></a>access_log</h3>
           <p class="desc">The file path of the HTTP access log.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -60,7 +52,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>path</td>
                   <td>String</td>
@@ -68,7 +59,6 @@
                   <td>The file path where the access log should be written</td>
                   <td></td>
                 </tr>
-              
                 <tr>
                   <td>format</td>
                   <td>String</td>
@@ -76,37 +66,27 @@
                   <td>The log file format; see <a href="http://www.senchalabs.org/connect/logger.html">Connect documentation</a> under "Formats"</td>
                   <td>default</td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> Top-level<br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="server"></a>server</h3>
           <p class="desc">Declares an HTTP server. You need one of these for each port/IP address combination this Shiny Server instance should listen on.</p>
-          
             <p class="noparams">This directive has no parameters.</p>
-          
 
           <p>
             <label>Applies to:</label> Top-level<br/>
             <label>Inheritable:</label> Yes<br/>
-            
               <label>Child directives:</label> <code><a href="#listen">listen</a></code>, <code><a href="#server_name">server_name</a></code><br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="listen"></a>listen</h3>
           <p class="desc">Directs the enclosing server scope to listen on the specified port/IP address combination.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -122,7 +102,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>port</td>
                   <td>Integer</td>
@@ -130,7 +109,6 @@
                   <td>Port to listen on</td>
                   <td></td>
                 </tr>
-              
                 <tr>
                   <td>host</td>
                   <td>String</td>
@@ -138,21 +116,16 @@
                   <td>IPv4 address to listen on (<code>*</code> or <code>0.0.0.0</code> for all); hostnames are not currently allowed, please use raw IPv4 address only</td>
                   <td>*</td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> <code><a href="#server">server</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="server_name"></a>server_name</h3>
           <p class="desc">Directs the enclosing server scope to only honor requests that have the given host headers (i.e. virtual hosts).</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -168,7 +141,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>names</td>
                   <td>String</td>
@@ -176,21 +148,16 @@
                   <td>The virtual hostname(s) to bind this server to</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> <code><a href="#server">server</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="location"></a>location</h3>
           <p class="desc">Creates a scope that configures the given URL as a website (<a class="code" href="#site_dir">site_dir</a>), specific application (<a class="code" href="#app_dir">app_dir</a>), autouser root (<a class="code" href="#user_apps">user_apps</a>), autouser root with <a class="code" href="#run_as">run_as</a> support (<a class="code" href="#user_dirs">user_dirs</a>), or redirect to a different URL (<a class="code" href="#redirect">redirect</a>).</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -206,7 +173,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>path</td>
                   <td>String</td>
@@ -214,23 +180,17 @@
                   <td>The request path that this location should match</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
-              <label>Child directives:</label> <code><a href="#run_as">run_as</a></code>, <code><a href="#location">location</a></code>, <code><a href="#site_dir">site_dir</a></code>, <code><a href="#directory_index">directory_index</a></code>, <code><a href="#user_apps">user_apps</a></code>, <code><a href="#user_dirs">user_dirs</a></code>, <code><a href="#app_dir">app_dir</a></code>, <code><a href="#redirect">redirect</a></code>, <code><a href="#log_dir">log_dir</a></code>, <code><a href="#members_of">members_of</a></code>, <code><a href="#google_analytics_id">google_analytics_id</a></code>, <code><a href="#application">application</a></code>, <code><a href="#template_dir">template_dir</a></code><br/>
-            
+              <label>Child directives:</label> <code><a href="#run_as">run_as</a></code>, <code><a href="#location">location</a></code>, <code><a href="#site_dir">site_dir</a></code>, <code><a href="#directory_index">directory_index</a></code>, <code><a href="#user_apps">user_apps</a></code>, <code><a href="#user_dirs">user_dirs</a></code>, <code><a href="#app_dir">app_dir</a></code>, <code><a href="#redirect">redirect</a></code>, <code><a href="#log_dir">log_dir</a></code>, <code><a href="#members_of">members_of</a></code>, <code><a href="#google_analytics_id">google_analytics_id</a></code>, <code><a href="#application">application</a></code>, <code><a href="#template_dir">template_dir</a></code>, <code><a href="#bookmark_state_dir">bookmark_state_dir</a></code>, <code><a href="#disable_websockets">disable_websockets</a></code>, <code><a href="#disable_protocols">disable_protocols</a></code>, <code><a href="#log_as_user">log_as_user</a></code>, <code><a href="#reconnect">reconnect</a></code>, <code><a href="#sanitize_errors">sanitize_errors</a></code>, <code><a href="#whitelist_headers">whitelist_headers</a></code><br/>
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="site_dir"></a>site_dir</h3>
           <p class="desc">Configures the enclosing location scope to be a website that can contain both Shiny applications and unrelated static assets in a single directory tree.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -246,7 +206,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>rootPath</td>
                   <td>String</td>
@@ -254,21 +213,16 @@
                   <td>The path to the root directory of the website</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="directory_index"></a>directory_index</h3>
           <p class="desc">When enabled, if a directory is requested by the client and an <code>index.html</code> file is not present, a list of the directory contents is created automatically and returned to the client. If this directive is not present in a custom config file, the default behavior is to disable directory indexes. However, it is enabled if no config file is present at all (in other words, the default config file has it enabled).</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -284,7 +238,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>enabled</td>
                   <td>Boolean</td>
@@ -292,21 +245,16 @@
                   <td>Whether directory contents should automatically displayed</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="user_apps"></a>user_apps</h3>
           <p class="desc">DEPRECATED! This directive has been deprecated in favor of <a class="code" href="#user_dirs">user_dirs</a>, which offers more flexibility with regards to the <a class="code" href="#run_as">run_as</a> configuration. Configures the enclosing location scope to be an autouser root, meaning that applications will be served up from users' ~/ShinyApps directories and all Shiny processes will run as the user in whose directory the application is found.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -322,7 +270,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>enabled</td>
                   <td>Boolean</td>
@@ -330,21 +277,16 @@
                   <td>Whether this location should serve up all users' ~/ShinyApps directories</td>
                   <td>true</td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="user_dirs"></a>user_dirs</h3>
           <p class="desc">Configures the enclosing location scope to be an autouser root, meaning that applications will be served up from users' ~/ShinyApps directories. This directive does respect an affiliated run_as setting, meaning that the applications will be executed as whichever user is configured in the applicable run_as setting. Note that many distributions, by default, will prohibit users from being able to access each other's home directories.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -360,7 +302,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>enabled</td>
                   <td>Boolean</td>
@@ -368,21 +309,16 @@
                   <td>Whether this location should serve up all users' ~/ShinyApps directories</td>
                   <td>true</td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="app_dir"></a>app_dir</h3>
           <p class="desc">Configures the enclosing location scope to serve up the specified Shiny application.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -398,7 +334,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>path</td>
                   <td>String</td>
@@ -406,21 +341,16 @@
                   <td>The path to the Shiny application directory</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="redirect"></a>redirect</h3>
           <p class="desc">Configures the enclosing location to redirect all requests to the specified URL.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -436,7 +366,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>url</td>
                   <td>String</td>
@@ -444,7 +373,6 @@
                   <td>The URL (or base URL) to redirect to</td>
                   <td></td>
                 </tr>
-              
                 <tr>
                   <td>statusCode</td>
                   <td>Integer</td>
@@ -452,7 +380,6 @@
                   <td>The status code to send with the response (usually 301 for permanent redirects or 302 for temporary redirects)</td>
                   <td>302</td>
                 </tr>
-              
                 <tr>
                   <td>exact</td>
                   <td>Boolean</td>
@@ -460,21 +387,16 @@
                   <td>Whether to match on the URL exactly; if false, any subpaths will match as well</td>
                   <td>true</td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="log_dir"></a>log_dir</h3>
           <p class="desc">Directs the application to write error logs to the specified directory. Only applies to location scopes that are configured with <a class="code" href="#app_dir">app_dir</a> or <a class="code" href="#site_dir">site_dir</a>, as <a class="code" href="#user_apps">user_apps</a> (autouser) always writes error logs to <code>~/ShinyApps/log</code>.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -490,7 +412,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>path</td>
                   <td>String</td>
@@ -498,21 +419,16 @@
                   <td>The path to which application log files should be written</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="members_of"></a>members_of</h3>
           <p class="desc">Restricts a <a class="code" href="#user_apps">user_apps</a> or <a class="code" href="#user_dirs">user_dirs</a> (autouser) scope to require membership in one or more groups (or, if no arguments are passed, lifts group restrictions from a <a class="code" href="#members_of">members_of</a> directive in a parent scope).</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -528,7 +444,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>groups</td>
                   <td>String</td>
@@ -536,21 +451,16 @@
                   <td>Users must be a member of at least one of these groups in order to deploy applications; if no groups are provided, then all users are allowed</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="google_analytics_id"></a>google_analytics_id</h3>
           <p class="desc">Configure Google Analytics tracking code to be inserted in Shiny application pages.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -566,7 +476,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>gaid</td>
                   <td>String</td>
@@ -574,21 +483,16 @@
                   <td>The Google tracking ID, for example, UA-18988-1</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="app_init_timeout"></a>app_init_timeout</h3>
           <p class="desc">Defines the amount of time Shiny Server will wait for an R process to start before giving up.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -604,7 +508,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>timeout</td>
                   <td>Integer</td>
@@ -612,21 +515,16 @@
                   <td>The number of seconds to wait for the application to start.</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code>, <code><a href="#application">application</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="app_idle_timeout"></a>app_idle_timeout</h3>
           <p class="desc">Defines the amount of time an R process will persist with no connections before being terminated.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -642,7 +540,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>timeout</td>
                   <td>Integer</td>
@@ -650,21 +547,16 @@
                   <td>The number of seconds to keep an empty R process alive before killing it.</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code>, <code><a href="#application">application</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="simple_scheduler"></a>simple_scheduler</h3>
           <p class="desc">A basic scheduler which will spawn one single-threaded R worker for each application. If no scheduler is specified, this is the default scheduler.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -680,7 +572,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>maxRequests</td>
                   <td>Integer</td>
@@ -688,21 +579,16 @@
                   <td>The maximum number of requests to assign to this scheduler before it should start returning rejecting incoming traffic using a '503 - Service Unavailable' message. Once this threshold is hit, users attempting to initialize a new session will receive 503 errors.</td>
                   <td>100</td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code>, <code><a href="#application">application</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="allow_app_override"></a>allow_app_override</h3>
           <p class="desc">If present, will allow users to override the global defaults for a scheduler by customizing the parameters associated with a scheduler or even the type of scheduler used.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -718,7 +604,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>enabled</td>
                   <td>Boolean</td>
@@ -726,21 +611,16 @@
                   <td>Whether or not this is enabled. Default is true.</td>
                   <td>true</td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> Top-level<br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="application"></a>application</h3>
           <p class="desc">DEPRECATED. This setting is deprecated and no longer enforced in Shiny Server. It will be ignored.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -756,7 +636,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>empty</td>
                   <td>String</td>
@@ -764,23 +643,17 @@
                   <td></td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
               <label>Child directives:</label> <code><a href="#app_init_timeout">app_init_timeout</a></code>, <code><a href="#app_idle_timeout">app_idle_timeout</a></code>, <code><a href="#simple_scheduler">simple_scheduler</a></code><br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="template_dir"></a>template_dir</h3>
           <p class="desc">A directory containing custom templates to be used when generating pages in Shiny Server.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -796,7 +669,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>dir</td>
                   <td>String</td>
@@ -804,21 +676,16 @@
                   <td>The directory containing HTML templates.</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
 
           <p>
             <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
-          <h3 class="code"><a name="disable_websockets"></a>disable_websockets</h3>
-          <p class="desc">Disable WebSockets on connections to the server. Some networks will not reliably support WebSockets, so this setting can be used to force Shiny Server to fall back to another protocol to communicate with the server. This is equivalent to adding 'websocket' to <code>disabled_protocols</code></p>
-          
+          <h3 class="code"><a name="bookmark_state_dir"></a>bookmark_state_dir</h3>
+          <p class="desc">A directory for storing persisted application state. If Shiny Server is running without root privileges, then the <a class="code" href="#run_as">run_as</a> account must have read/write access to this directory. If no <a class="code" href="#bookmark_state_dir">bookmark_state_dir</a> directive is provided, <code>/var/lib/shiny-server/bookmarks</code> will be used.</p>
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -834,7 +701,38 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
+                <tr>
+                  <td>dir</td>
+                  <td>String</td>
+                  <td>required</td>
+                  <td>The directory where bookmark data should be stored.</td>
+                  <td></td>
+                </tr>
+            </table>
+
+          <p>
+            <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
+            <label>Inheritable:</label> Yes<br/>
+          </p>
+        </li>
+        <li>
+          <h3 class="code"><a name="disable_websockets"></a>disable_websockets</h3>
+          <p class="desc">Disable WebSockets on connections to the server. Some networks will not reliably support WebSockets, so this setting can be used to force Shiny Server to fall back to another protocol to communicate with the server. This is equivalent to adding 'websocket' to <code>disabled_protocols</code></p>
+            <table class="params">
+              <colgroup>
+                <col style="width: 105px"></col>
+                <col style="width: 90px"></col>
+                <col style="width: 90px"></col>
+                <col></col>
+                <col style="width: 90px"></col>
+              </colgroup>
+              <tr>
+                <th>Parameter</th>
+                <th>Data type</th>
+                <th>Type</th>
+                <th>Description</th>
+                <th>Default</th>
+              </tr>
                 <tr>
                   <td>val</td>
                   <td>Boolean</td>
@@ -842,21 +740,16 @@
                   <td>Whether or not WebSockets should be disabled.</td>
                   <td>true</td>
                 </tr>
-              
             </table>
-          
 
           <p>
-            <label>Applies to:</label> Top-level<br/>
+            <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
         <li>
           <h3 class="code"><a name="disable_protocols"></a>disable_protocols</h3>
           <p class="desc">Disable some of the SockJS protocols used to establish a connection between your users and your server. Some network configurations cause problems with particular protocols; this option allows you to disable those.</p>
-          
             <table class="params">
               <colgroup>
                 <col style="width: 105px"></col>
@@ -872,7 +765,6 @@
                 <th>Description</th>
                 <th>Default</th>
               </tr>
-              
                 <tr>
                   <td>names</td>
                   <td>String</td>
@@ -880,15 +772,171 @@
                   <td>The protocol(s) to disable. Available protocols are: 'websocket', 'xdr-streaming', 'xhr-streaming', 'iframe-eventsource', 'iframe-htmlfile', 'xdr-polling', 'xhr-polling', 'iframe-xhr-polling', 'jsonp-polling'</td>
                   <td></td>
                 </tr>
-              
             </table>
-          
+
+          <p>
+            <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
+            <label>Inheritable:</label> Yes<br/>
+          </p>
+        </li>
+        <li>
+          <h3 class="code"><a name="preserve_logs"></a>preserve_logs</h3>
+          <p class="desc">By default, log files from Shiny processes that exited successfully (exit status 0) will be deleted. This behavior can be overridden by setting this property to <code>true</code> in which case Shiny Server will not delete the log files from any Shiny process that it spawns. WARNING: This feature should only be enabled when combined with proper log rotation. Otherwise, thousands of log files could quickly accrue and cause problems for the file system on which they are stored.</p>
+            <table class="params">
+              <colgroup>
+                <col style="width: 105px"></col>
+                <col style="width: 90px"></col>
+                <col style="width: 90px"></col>
+                <col></col>
+                <col style="width: 90px"></col>
+              </colgroup>
+              <tr>
+                <th>Parameter</th>
+                <th>Data type</th>
+                <th>Type</th>
+                <th>Description</th>
+                <th>Default</th>
+              </tr>
+                <tr>
+                  <td>enabled</td>
+                  <td>Boolean</td>
+                  <td>optional</td>
+                  <td>Whether or not logs should be preserved.</td>
+                  <td>false</td>
+                </tr>
+            </table>
 
           <p>
             <label>Applies to:</label> Top-level<br/>
             <label>Inheritable:</label> Yes<br/>
-            
           </p>
         </li>
-      
+        <li>
+          <h3 class="code"><a name="log_as_user"></a>log_as_user</h3>
+          <p class="desc">By default, the log files for R processes are created and managed by the user running the server centrally (often root). In the typical scenario in which the logs are stored in a server-wide directory, this is desirable as only root user may have write access to such a directory. In other cases, such as using <a class="code" href="#user_dirs">user_dirs</a> on a system in which the users' home directories are on an NFS mount which uses <code>root_squash</code>, creating log files as root may be a problem. In those scenarios, this option can be set to true to have the log files created by the users running the associated processes.</p>
+            <table class="params">
+              <colgroup>
+                <col style="width: 105px"></col>
+                <col style="width: 90px"></col>
+                <col style="width: 90px"></col>
+                <col></col>
+                <col style="width: 90px"></col>
+              </colgroup>
+              <tr>
+                <th>Parameter</th>
+                <th>Data type</th>
+                <th>Type</th>
+                <th>Description</th>
+                <th>Default</th>
+              </tr>
+                <tr>
+                  <td>enabled</td>
+                  <td>Boolean</td>
+                  <td>optional</td>
+                  <td>Whether or not the log files should be managed by the owner of the process to which they belong.</td>
+                  <td>false</td>
+                </tr>
+            </table>
+
+          <p>
+            <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
+            <label>Inheritable:</label> Yes<br/>
+          </p>
+        </li>
+        <li>
+          <h3 class="code"><a name="reconnect"></a>reconnect</h3>
+          <p class="desc">When a user's connection to the server is interrupted, Shiny Server will offer them a dialog that allows them to reconnect to their existing Shiny session for 15 seconds. This implies that the server will keep the Shiny session active on the server for an extra 15 seconds after a user disconnects in case they reconnect. After the 15 seconds, the user's session will be reaped and they will be notified and offered an opportunity to refresh the page. If this setting is true, the server will immediately reap the session of any user who is disconnected.</p>
+            <table class="params">
+              <colgroup>
+                <col style="width: 105px"></col>
+                <col style="width: 90px"></col>
+                <col style="width: 90px"></col>
+                <col></col>
+                <col style="width: 90px"></col>
+              </colgroup>
+              <tr>
+                <th>Parameter</th>
+                <th>Data type</th>
+                <th>Type</th>
+                <th>Description</th>
+                <th>Default</th>
+              </tr>
+                <tr>
+                  <td>enabled</td>
+                  <td>Boolean</td>
+                  <td>optional</td>
+                  <td>Whether or not to offer to automatically reconnect disconnected users.</td>
+                  <td>true</td>
+                </tr>
+            </table>
+
+          <p>
+            <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
+            <label>Inheritable:</label> Yes<br/>
+          </p>
+        </li>
+        <li>
+          <h3 class="code"><a name="sanitize_errors"></a>sanitize_errors</h3>
+          <p class="desc">If this setting is true (the default), only generic error messages will be shown to the client (unless these were wrapped in <code>safeError()</code>).</p>
+            <table class="params">
+              <colgroup>
+                <col style="width: 105px"></col>
+                <col style="width: 90px"></col>
+                <col style="width: 90px"></col>
+                <col></col>
+                <col style="width: 90px"></col>
+              </colgroup>
+              <tr>
+                <th>Parameter</th>
+                <th>Data type</th>
+                <th>Type</th>
+                <th>Description</th>
+                <th>Default</th>
+              </tr>
+                <tr>
+                  <td>enabled</td>
+                  <td>Boolean</td>
+                  <td>optional</td>
+                  <td>Whether or not to sanitize error messages on the client.</td>
+                  <td>true</td>
+                </tr>
+            </table>
+
+          <p>
+            <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
+            <label>Inheritable:</label> Yes<br/>
+          </p>
+        </li>
+        <li>
+          <h3 class="code"><a name="whitelist_headers"></a>whitelist_headers</h3>
+          <p class="desc">Allow specific headers to pass through to the shiny apps, useful to detect browser attributes or get specific information from a proxy.</p>
+            <table class="params">
+              <colgroup>
+                <col style="width: 105px"></col>
+                <col style="width: 90px"></col>
+                <col style="width: 90px"></col>
+                <col></col>
+                <col style="width: 90px"></col>
+              </colgroup>
+              <tr>
+                <th>Parameter</th>
+                <th>Data type</th>
+                <th>Type</th>
+                <th>Description</th>
+                <th>Default</th>
+              </tr>
+                <tr>
+                  <td>names</td>
+                  <td>String</td>
+                  <td>multiple</td>
+                  <td>The headers to let through. Examples are: 'referer', 'user-agent', 'x-my-special-header'</td>
+                  <td></td>
+                </tr>
+            </table>
+
+          <p>
+            <label>Applies to:</label> Top-level, <code><a href="#server">server</a></code>, <code><a href="#location">location</a></code><br/>
+            <label>Inheritable:</label> Yes<br/>
+          </p>
+        </li>
     </ul>

--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -216,3 +216,10 @@ sanitize_errors {
   at $ server location;
   maxcount 1;
 }
+
+whitelist_headers {
+  desc "Allow specific headers to pass through to the shiny apps, useful to detect browser attributes or get specific information from a proxy.";
+  param String names... "The headers to let through. Examples are: referer, user-agent, x-my-special-header";
+  at $ server location;
+  maxcount 1;
+}

--- a/config/whitelist_headers.config
+++ b/config/whitelist_headers.config
@@ -1,0 +1,14 @@
+# Instruct Shiny Server to run applications as the user "shiny"
+run_as shiny;
+
+# Define a server that listens on port 3838
+server {
+  listen 3838;
+
+  # Define a location at the base URL
+  location / {
+
+    # Allow referer and user-agent to pass through from the original request to the shiny app
+    whitelist_headers referer user-agent;
+  }
+}

--- a/lib/proxy/http.js
+++ b/lib/proxy/http.js
@@ -120,14 +120,16 @@ function ShinyProxy(router, schedulerRegistry) {
         req.url = '/' + req.url;
       // TODO: Also strip path members
 
+      
+      var headers = _.pick(req.headers, appSpec.settings.appDefaults.whitelistedHeaders);
       //TODO: clean this up. This should be a part of the promise chain, but
       // when returning an error, it would just crash as an unhandled excptn
       // and never make it into the .fail().
       var wrk;
       try{
         // Extract the non-param portion of the URL
-        wrk = schedulerRegistry.getWorker_p(appSpec, req.url.match(/([^\?]+)(\?.*)?/)[1], 
-        worker)
+        wrk = schedulerRegistry.getWorker_p(appSpec, req.url.match(/([^\?]+)(\?.*)?/)[1],
+        worker, headers)
       }
       catch(err){
         if (err instanceof OutOfCapacityError){

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -149,7 +149,7 @@ function createServer(router, schedulerRegistry) {
       }
 
       pathInfo = pathInfo.replace(/\/__sockjs__\/.*/, "/websocket/");
-      wsClient = appWorkerHandle.endpoint.createWebSocketClient(pathInfo);
+      wsClient = appWorkerHandle.endpoint.createWebSocketClient(pathInfo, appWorkerHandle.headers);
 
       wsClient.onopen = function(event) {
         conn.removeListener('data', connDataHandler);

--- a/lib/router/config-router-util.js
+++ b/lib/router/config-router-util.js
@@ -52,6 +52,7 @@ function parseApplication(settings, locNode, provideDefaults){
     appSettings.sanitizeErrors = true;
     appSettings.disableProtocols = [];
     appSettings.bookmarkStateDir = '/var/lib/shiny-server/bookmarks';
+    appSettings.whitelistedHeaders = [];
   }
 
   if (locNode.getValues('app_idle_timeout') &&
@@ -89,6 +90,12 @@ function parseApplication(settings, locNode, provideDefaults){
       }
     });
   }
+
+  var whitelistHeadersNode = locNode.getOne('whitelist_headers', true);
+  if (whitelistHeadersNode && whitelistHeadersNode.values.names) {
+    appSettings.whitelistedHeaders = whitelistHeadersNode.values.names;
+  }
+
   if (locNode.getValues('disable_websockets').val){
     appSettings.disableProtocols.push('websocket');
   }

--- a/lib/scheduler/scheduler-registry.js
+++ b/lib/scheduler/scheduler-registry.js
@@ -63,7 +63,7 @@ module.exports = SchedulerRegistry;
    *   targetting. If left blank, an arbitrary worker will be selected. Ignored
    *   when using the SimpleScheduler.
    */
-  this.getWorker_p = function(appSpec, url, worker) {
+  this.getWorker_p = function(appSpec, url, worker, headers) {
     var key = appSpec.getKey();
     if (!this.$schedulers[key]){
       //no scheduler, instantiate a simple scheduler
@@ -72,9 +72,9 @@ module.exports = SchedulerRegistry;
       if (this.$transport){
         this.$schedulers[key].setTransport(this.$transport);
       }
-    }  
-    
-    return this.$schedulers[key].acquireWorker_p(appSpec, url, worker); 
+    }
+
+    return this.$schedulers[key].acquireWorker_p(appSpec, url, worker, headers);
   };
 
   this.shutdown = function() {

--- a/lib/scheduler/scheduler.js
+++ b/lib/scheduler/scheduler.js
@@ -221,7 +221,7 @@ function connectEndpoint_p(endpoint, timeout, shouldContinue) {
       return workerPromise.then(function(appWorker) {
         var appWorkerHandle = new AppWorkerHandle(appSpec, endpoint,
           logFilePath, exitPromise,
-          _.bind(appWorker.kill, appWorker));
+          _.bind(appWorker.kill, appWorker), workerData.headers);
 
 
         var initTimeout = 60 * 1000;

--- a/lib/scheduler/simple-scheduler.js
+++ b/lib/scheduler/simple-scheduler.js
@@ -31,7 +31,7 @@ util.inherits(SimpleScheduler, Scheduler);
 	 * Defines how this schedule will identify and select an R process to 
 	 * fulfill its requests.
 	 */
-	this.acquireWorker_p = function(appSpec, url){
+	this.acquireWorker_p = function(appSpec, url, worker, headers){
 	    if (this.$workers && _.size(this.$workers) > 0) {
 	      logger.trace('Reusing existing instance');
 
@@ -65,7 +65,7 @@ util.inherits(SimpleScheduler, Scheduler);
 	    }
 
 	    logger.trace('Spawning new instance');
-	    return this.spawnWorker_p(appSpec);
+	    return this.spawnWorker_p(appSpec, {headers: headers});
 	};
 
 }).call(SimpleScheduler.prototype);

--- a/lib/worker/app-worker-handle.js
+++ b/lib/worker/app-worker-handle.js
@@ -14,7 +14,7 @@ var events = require('events');
 var util = require('util');
 
 var AppWorkerHandle = function(appSpec, endpoint, logFilePath,
-    exitPromise, kill) {
+    exitPromise, kill, headers) {
 
   events.EventEmitter.call(this);
   this.appSpec = appSpec;
@@ -22,6 +22,7 @@ var AppWorkerHandle = function(appSpec, endpoint, logFilePath,
   this.logFilePath = logFilePath;
   this.exitPromise = exitPromise;
   this.kill = kill;
+  this.headers = headers;
 };
 module.exports = AppWorkerHandle;
 

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   "license": "AGPL-3.0",
   "engines": {
     "node": ">=6.6.0"
+  },
+  "devDependencies": {
+    "escape-html": "^1.0.3"
   }
 }

--- a/samples/sample-apps/headers/server.R
+++ b/samples/sample-apps/headers/server.R
@@ -1,0 +1,19 @@
+library(shiny)
+
+shinyServer(function(input, output, session) {
+
+  output$summary <- renderText({
+    ls(env=session$request)
+  })
+
+  output$headers <- renderUI({
+    selectInput("header", "Header:", ls(env=session$request))
+  })
+
+  output$value <- renderText({
+    if (nchar(input$header) < 1 || !exists(input$header, envir=session$request)){
+      return("NULL");
+    }
+    return (get(input$header, envir=session$request));
+  })
+})

--- a/samples/sample-apps/headers/ui.R
+++ b/samples/sample-apps/headers/ui.R
@@ -1,0 +1,12 @@
+shinyUI(pageWithSidebar(
+  headerPanel("Shiny Client Data"),
+  sidebarPanel(
+    uiOutput("headers")
+  ),
+  mainPanel(
+    h3("Headers passed into Shiny"),
+    verbatimTextOutput("summary"),
+    h3("Value of specified header"),
+    verbatimTextOutput("value")
+  )
+))

--- a/tools/makedocs.js
+++ b/tools/makedocs.js
@@ -17,13 +17,13 @@
  * This script is for generating config.html. It is designed to run under
  * node-supervisor (https://github.com/isaacs/node-supervisor).
  *
- *   supervisor -n exit --extensions 'js|html' lib/makedocs.js
+ *   supervisor -n exit --extensions 'js|html' tools/makedocs.js
  */
 
 var fs = require('fs');
 var path = require('path');
 var util = require('util');
-var htmlEscape = require('connect/lib/utils').escape;
+var htmlEscape = require('escape-html');
 var Handlebars = require('handlebars');
 var _ = require('underscore');
 var map = require('../lib/core/map');


### PR DESCRIPTION
Added whitelist_headers configuration to shiny-server.conf.

This can be useful to adapt a report depending on the browser/referer of the visitor, or to relay additional information from a proxy sitting between the browser and shiny-server.