### PR TITLE
Fix #506: R process not terminating in certain scenario

### DIFF
--- a/lib/proxy/http.js
+++ b/lib/proxy/http.js
@@ -55,6 +55,16 @@ function error500(req, res, errorText, detail, templateDir, consoleLogFile, appS
   .done();
 }
 
+// All the http_proxy events we know about. They have a frustrating habit of
+// changing these around.
+var knownEvents = exports.knownEvents = ['open', 'close', 'proxyReq', 'proxyRes', 'proxySocket',
+  'start', 'end', 'error',
+  // Known, but undocumented
+  'econnreset',
+  // Undocumented and unknown
+  'proxyReqWs'
+];
+
 exports.ShinyProxy = ShinyProxy;
 /**
  * ShinyProxy combines HTTP and websocket proxying duties, and manages these
@@ -215,7 +225,6 @@ function ShinyProxy(router, schedulerRegistry) {
     delete response.appWorkerHandle;
   }
 
-
   // Create an HTTP proxy object for the given socket; we need one of these per
   // active socket. node-http-proxy has a RoutingProxy that provides a more
   // suitable interface (you can specify a different target for each call to
@@ -226,6 +235,16 @@ function ShinyProxy(router, schedulerRegistry) {
     var proxy = new http_proxy.createProxyServer({
       target: appWorkerHandle.endpoint.getHttpProxyTarget()
     });
+
+    // Intercept http_proxy events, for debugging/warning purposes.
+    var origEmit = proxy.emit;
+    proxy.emit = function(type) {
+      logger.trace("http_proxy event: " + type);
+      if (!knownEvents.includes(type)) {
+        logger.warn("Unexpected http_proxy event: " + type);
+      }
+      origEmit.apply(this, arguments);
+    };
 
     // Once we switched the connection between node and the R workers from TCP
     // to Unix domain sockets, keepalive management from the node side seemed
@@ -251,6 +270,12 @@ function ShinyProxy(router, schedulerRegistry) {
       // if the upstream server drops the connection.
       error500(req, res, 'The application exited unexpectedly.', err.message,
           req.templateDir, appWorkerHandle.logFilePath, appWorkerHandle.appSpec);
+      cleanupResponse(res);
+    });
+    // This happens if the proxy-to-target request is disconnected. One easy way
+    // to trigger this, as of this writing, is to have an app.R that has a
+    // Sys.sleep(120) in ui.R.
+    proxy.on('econnreset', function(err, req, res) {
       cleanupResponse(res);
     });
     proxy.on('end', function(req, res) {

--- a/test/proxy-events.js
+++ b/test/proxy-events.js
@@ -1,0 +1,68 @@
+/*
+ * test/proxy-events.js
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * This program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+const child_process = require("child_process");
+
+const bash = require("bash");
+const _ = require("underscore");
+
+const proxy_http = require("../lib/proxy/http");
+
+describe("http-proxy", () => {
+
+  // Burned several times now by http-proxy changing its events. Let's
+  // at least fail some tests if they add or remove event names.
+  it("has not changed its supported events", (done) => {
+    let knownEvents = proxy_http.knownEvents;
+
+    let pipeline = [
+      // Find all instances of ".emit(..."
+      // Since we're using -o and -h, only the actual matches will be printed
+      ["grep", "-Roh", "\\.emit([^,]\\+", "node_modules/http-proxy"],
+      // Strip the ".emit(" prefix
+      ["sed", "s/\\.emit(//"],
+      // Strip quotation marks, whitespace
+      ["sed", "s/['\" ]//g"],
+      // Remove dupes with sort+uniq
+      ["sort"],
+      ["uniq"]
+    ];
+
+    pipeline = _.map(pipeline, (args) => bash.escape.apply(bash, args));
+
+    child_process.exec(pipeline.join("|"),
+      (error, stdout, stderr) => {
+        if (error) {
+          done(error);
+          return;
+        }
+
+        let actualEvents = stdout.trim().split("\n");
+
+        let fictional = _.difference(proxy_http.knownEvents, actualEvents);
+        let discovered = _.difference(actualEvents, proxy_http.knownEvents);
+
+        if (fictional.length > 0) {
+          done(new Error("Detected fictional event(s): " + fictional.join(", ")));
+          return;
+        }
+        if (discovered.length > 0) {
+          done(new Error("Discovered new event(s): " + discovered.join(", ")));
+          return;
+        }
+        done();
+      }
+    );
+
+  });
+});


### PR DESCRIPTION
Bitten again by node-http-proxy event changes :( When an ECONNRESET
occurs between the proxy and the target (Shiny process), we were
expecting to see that error come in on the "error" event (and in
earlier versions it was "proxyError"). But earlier this year, this
specific error code was pulled out of the "error" event and raised
as a unique "econnreset" event, without the docs being updated.

Also added a test so the build will fail if we upgrade http-proxy
and it adds new events.