### PR TITLE
Fix SockJS transport fallback

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+shiny-server 1.5.1
+--------------------------------------------------------------------------------
+
+* Improve robustness with unfriendly proxy configurations. This had regressed
+  some time between 1.4.3 and 1.4.7. (PR #263)
+
 shiny-server 1.5.0
 --------------------------------------------------------------------------------
 

--- a/lib/proxy/robust-sockjs.js
+++ b/lib/proxy/robust-sockjs.js
@@ -11,6 +11,7 @@
  *
  */
 
+var assert = require('assert');
 var util = require('util');
 var events = require('events');
 var crypto = require('crypto');
@@ -77,21 +78,31 @@ function RobustSockJSRegistry(timeout){
         // Reconnecting to an existing session
         logger.debug("Reconnecting to robust connection: " + id);
 
-        self._connections[id].set(conn);
+        self._connections[id].set(conn, true);
         // Return falsey as no further processing/wiring is needed on this connection.
         return;
       } else {
         // Trying to create a new session with a colliding ID
-        logger.warn("RobustSockJS collision: " + id);
-        conn.close(errorcode.BAD_IDENTIFIER, "Unable to open connection");
-        return;
+        if (self._connections[id].nascent) {
+          logger.debug("Resuming a nascent robust connection: " + id);
+          // We'll allow it in this case, because the previous connection never
+          // actually received any messages. Probably this is a case where the
+          // SockJS transport failed but we didn't realize it.
+          self._connections[id].set(conn, false);
+          return;
+        } else {
+          logger.warn("RobustSockJS collision: " + id);
+          conn.close(errorcode.BAD_IDENTIFIER,
+            "Unable to open connection (RobustSockJS collision)");
+          return;
+        }
       }
     } else {
       // ID not found in table
 
       if (existing) {
         // Trying to resume a session which we don't have a record of.
-        logger.debug("Disconnecting client because ID wasn't found.");
+        logger.debug("Disconnecting robust connection because ID wasn't found: " + id);
         conn.close(errorcode.BAD_IDENTIFIER, 'Your session could not be resumed on the server.');
         return;
       } else {
@@ -111,6 +122,16 @@ function RobustSockJSRegistry(timeout){
     events.EventEmitter.call(this);
 
     var robustConn = this;
+
+    // If the nascent flag is true, it means that this RobustConn has not yet
+    // received any data from the client (even though a connection might have
+    // been established). If a RobustConn is nascent, it's permitted to call
+    // robustConn.set(conn, false), which is more or less the same as saying
+    // "pretend the previous/existing (underlying) this._conn didn't exist,
+    // just treat this new conn as if it's the first one". This is necessary
+    // for SockJS transport failure/fallback to work properly. See the comment
+    // on this.set().
+    this.nascent = true;
 
     this._messageBuffer = new MessageBuffer();
     this._messageReceiver = new MessageReceiver();
@@ -155,8 +176,26 @@ function RobustSockJSRegistry(timeout){
     });
     this._withheld = {timer: null, events: []};
 
-    // Swap out the SockJS connection behind this RobustConn
-    this.set = function(conn){
+    // Swap out the SockJS connection behind this RobustConn.
+    //
+    // There are three reasons for doing this:
+    //
+    // - This is a totally new robustConn that has never seen a connection.
+    //   Essentially this is just finishing initialization of the robustConn. 
+    // - We had an existing conversation going, and the connection was broken,
+    //   and now a new connection has arrived. We should clean out the old
+    //   connection (if we still have it), and we will send, and expect to
+    //   receive, CONTINUE messages on the new connection.
+    // - We have an existing connection, but the conversation never actually
+    //   got started, and now a new connection has arrived. We see this in the
+    //   wild when SockJS connections are mangled by proxies, like nginx with
+    //   `proxy_http_version 1.0` (the default) which will kill xhr-streaming.
+    //   We think the connection succeeded but our response to the client is
+    //   cut short, so they think the conversation never got started. In this
+    //   case, we're not going to receive any CONTINUE message and we should
+    //   not send one, but act as if an implicit CONTINUE 0 message was
+    //   received.
+    this.set = function(conn, resume){
       if (robustConn._conn) {
         // Retire old connection
 
@@ -176,15 +215,42 @@ function RobustSockJSRegistry(timeout){
           robustConn._withheld.timer = 0;
         }
 
-        // Tell the BufferedResendConnection (on the client) what message ID we
-        // had been expecting before we got disconnected. If we had missed any
-        // messages in the meantime, they can send them now.
-        conn.write(robustConn._messageReceiver.CONTINUE());
-        // The next message we receive better be the other side sending CONTINUE
-        // to us too. This is not in response to our CONTINUE, but symmetrical
-        // to it; both sides should send CONTINUE to each other immediately upon
-        // reconnection.
-        this._expectContinue = true;
+        if (resume) {
+          // Tell the BufferedResendConnection (on the client) what message ID we
+          // had been expecting before we got disconnected. If we had missed any
+          // messages in the meantime, they can send them now.
+          conn.write(robustConn._messageReceiver.CONTINUE());
+          // The next message we receive better be the other side sending CONTINUE
+          // to us too. This is not in response to our CONTINUE, but symmetrical
+          // to it; both sides should send CONTINUE to each other immediately upon
+          // reconnection.
+          this._expectContinue = true;
+        } else {
+          // The client doesn't think we're resuming an existing connection, but
+          // creating a new one; yet we already have an existing connection. It
+          // had better be a nascent one.
+          assert(robustConn.nascent, "set(conn,false) was called on a mature RobustConn");
+
+          // OK, so we've got an essentially new connection here. The client
+          // isn't going to send CONTINUE because it thinks we're a new conn,'
+          // and it isn't expecting us to send CONTINUE either.
+
+          // It's conceivable (though I don't think currently possible) that
+          // messages were sent from us to the client already, in that case they
+          // certainly wouldn't have received them (because they think this is
+          // a new connection, and how could they have received messages over a
+          // connection that didn't exist yet). So go ahead and resend all of
+          // the messages in the buffer (guaranteed to start from 0 because for
+          // it not to, we would've needed to receive an ACK message and could
+          // therefore not possibly be nascent now).
+          var msgs = robustConn._messageBuffer.getMessagesFrom(0);
+          if (msgs.length > 0) {
+            logger.debug("Sending " + msgs.length + " buffered messages from nascent");
+          }
+          while (msgs.length) {
+            conn.write(msgs.shift());
+          }
+        }
       }
 
       // Set the new connection
@@ -205,6 +271,9 @@ function RobustSockJSRegistry(timeout){
           conn._oldEmit.apply(conn, arguments);
         }
         if (type === 'data') {
+          // As soon as we receive a single message, this robustConn is no
+          // longer consider nascent, but mature.
+          robustConn.nascent = false;
 
           // In this try block, we'll deal with the extra protocol stuff that
           // the client adds in BufferedResendConnection. Their side can send

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shiny-server",
   "preferGlobal": "true",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "RStudio <node@rstudio.com>",
   "description": "Application server for the Shiny web framework for R",
   "bin": "./lib/main.js",


### PR DESCRIPTION
(cc @trestletech @jonyoder @fereshtehRS)

This is a serious connectivity regression that was introduced with RobustSockJS (unclear whether it was the shiny-server-client version or the earlier one that introduced it). We should consider this for immediate patch of 1.5.0.

---

Before this fix, some proxy configurations were working for Shiny
Server 1.4.3 but not in 1.5.0. (I can't vouch for the state of
versions in between.)

Basically, with 1.4.3 SockJS was able to fall gracefully back from
websockets, to xhr-streaming, to xhr-polling. With 1.5.0, SockJS
does all this but when it finally finds a transport that works,
Shiny Server kills the connection, and in the server log there's a
message about RobustSockJS collision.

I believe this is because the proxy is letting the request through
correctly, but interrupting the response (for xhr-streaming). So
the server thinks the conversation has started, but the client
doesn't. When the client tries the next transport, it's still
trying to start a conversation, but now the server thinks the
client is using a robust-id (i.e. conversation ID) for a convo
that's already in progress, hence, collision.

This fix introduces a "nascent" flag for robust connections that
means the connection is newly created. Connections are considered
nascent only until they receive their first message from the client.
A nascent connection can be connected to using either "new" or
"continue" semantics (whereas before, any existing connection could
only be continued; attempting to treat them as new would result in
the RobustSockJS collision warning, and immediate closure of the
connection).

It is still NOT allowed to connect to an existing, non-nascent
connection using "new"--in that case the client and server are in
truly inconsistent states.

To repro this, you can use an nginx proxy configuration like so:

location / {
  proxy_pass http://localhost:3838;
  proxy_redirect http://localhost:3838/ $scheme://$host/;
}

and make sure xhr-streaming is enabled.

To see a correctly configured nginx proxy, visit:
https://support.rstudio.com/hc/en-us/articles/213733868-Running-Shiny-Server-with-a-Proxy