### PR TITLE
More control over http keepalive and sockjs timeouts

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,8 @@ shiny-server 1.5.2
 
 * Add additional configuration directives `http_keepalive_timeout`,
   `sockjs_heartbeat_delay`, and `sockjs_disconnect_delay` to allow working
-  with very slow connections and large SockJS payloads.
+  with very slow connections and large SockJS payloads. (The default values
+  for these options are the same as in previous versions of Shiny Server.)
 
 shiny-server 1.5.1
 --------------------------------------------------------------------------------

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+shiny-server 1.5.2
+--------------------------------------------------------------------------------
+
+* Add additional configuration directives `http_keepalive_timeout`,
+  `sockjs_heartbeat_delay`, and `sockjs_disconnect_delay` to allow working
+  with very slow connections and large SockJS payloads.
+
 shiny-server 1.5.1
 --------------------------------------------------------------------------------
 

--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -156,7 +156,7 @@ sockjs_heartbeat_delay {
 }
 
 sockjs_disconnect_delay {
-  desc "How long the SockJS server should wait between HTTP requests before considering the client to be disconnected.";
+  desc "How long the SockJS server should wait between HTTP requests before considering the client to be disconnected. Defaults to 5 seconds. If this value needs to be adjusted above 10 seconds, it's a good idea to disable websockets using the `disable_websockets` directive, as that transport protocol has an effective 10 second limit built in.";
   param Float delay "The number of seconds to wait before giving up.";
   at $;
   maxcount 1;

--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -141,6 +141,27 @@ app_idle_timeout {
   maxcount 1;
 }
 
+http_keepalive_timeout {
+  desc "Defines how long a keepalive connection will sit between HTTP requests/responses before it is closed. Defaults to 45 seconds.";
+  param Float timeout "The number of seconds to keep a connection alive between requests/responses.";
+  at $;
+  maxcount 1;
+}
+
+sockjs_heartbeat_delay {
+  desc "How often the SockJS server should send heartbeat packets to the server. These are used to prevent proxies and load balancers from closing active SockJS connections. Defaults to 25 seconds.";
+  param Float delay "The number of seconds to wait between heartbeat packets.";
+  at $;
+  maxcount 1;
+}
+
+sockjs_disconnect_delay {
+  desc "How long the SockJS server should wait between HTTP requests before considering the client to be disconnected.";
+  param Float delay "The number of seconds to wait before giving up.";
+  at $;
+  maxcount 1;
+}
+
 simple_scheduler {
   desc "A basic scheduler which will spawn one single-threaded R worker for each application. If no scheduler is specified, this is the default scheduler.";
   param Integer [maxRequests] "The maximum number of requests to assign to this scheduler before it should start returning rejecting incoming traffic using a '503 - Service Unavailable' message. Once this threshold is hit, users attempting to initialize a new session will receive 503 errors." 100;

--- a/lib/main.js
+++ b/lib/main.js
@@ -188,6 +188,13 @@ server.on('connection', function(socket) {
   // SockJS sends a heartbeat every 25s so as long as we wait significantly
   // longer than that to timeout, we shouldn't need to worry about closing
   // active connections.
+  //
+  // jcheng 11/17/2016: This doesn't work as well as you'd think. The timeout
+  // timer starts at e.g. the last invocation of write(), not waiting for
+  // that write to actually complete. In other words, there can be actual
+  // activity happening over the socket and yet the timeout can be hit. It's
+  // unclear whether the Node maintainers consider this a bug or not. See
+  // PR @rstudio/shiny-server#264 for all the gory details.
   socket.setTimeout(socketTimeout);
 });
 server.on('request', _.bind(app.handle, app));

--- a/lib/main.js
+++ b/lib/main.js
@@ -178,6 +178,8 @@ app.use(connect_util.filterByRegex(
 ));
 app.use(shinyProxy.httpListener);
 
+var socketTimeout = 45 * 1000;
+
 // Now create a server and hook everything up.
 var server = new Server();
 server.on('connection', function(socket) {
@@ -186,7 +188,7 @@ server.on('connection', function(socket) {
   // SockJS sends a heartbeat every 25s so as long as we wait significantly
   // longer than that to timeout, we shouldn't need to worry about closing
   // active connections.
-  socket.setTimeout(45 * 1000);
+  socket.setTimeout(socketTimeout);
 });
 server.on('request', _.bind(app.handle, app));
 server.on('error', function(err) {
@@ -226,8 +228,11 @@ var loadConfig_p = qutil.serialized(function() {
     transport.setSocketDir(configRouter.socketDir);
 
     // Create SockJS server
-    sockjsServer = proxy_sockjs.createServer(metarouter, schedulerRegistry);
+    sockjsServer = proxy_sockjs.createServer(metarouter, schedulerRegistry,
+      configRouter.sockjsHeartbeatDelay, configRouter.sockjsDisconnectDelay);
     sockjsHandler = sockjsServer.middleware();
+
+    socketTimeout = configRouter.httpKeepaliveTimeout;
 
     return createLogger_p(configRouter.accessLogSpec)
     .then(function(logfunc) {

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -22,7 +22,16 @@ var RobustSockJS = require('./robust-sockjs');
 var errorcode = require("./errorcode");
 
 exports.createServer = createServer;
-function createServer(router, schedulerRegistry) {
+function createServer(router, schedulerRegistry, heartbeatDelay, disconnectDelay) {
+  if (!heartbeatDelay || heartbeatDelay < 0) {
+    logger.warn("Ignoring invalid SockJS heartbeat delay: " + heartbeatDelay);
+    heartbeatDelay = 25 * 1000;
+  }
+  if (!disconnectDelay || disconnectDelay < 0) {
+    logger.warn("Ignoring invalid SockJS disconnect delay: " + disconnectDelay);
+    disconnectDelay = 5 * 1000;
+  }
+
   // Create a single SockJS server that will serve all applications. We'll use
   // the connection.url to dispatch among the different worker processes'
   // websocket ports. Once a connection is established, we simply pipe IO
@@ -31,7 +40,9 @@ function createServer(router, schedulerRegistry) {
     // TODO: make URL configurable
     sockjs_url: '//d1fxtkz8shb9d2.cloudfront.net/sockjs-0.3.min.js',
     prefix: '.*/__sockjs__(/[no]=\\w+)?',
-		log: function() {}
+    log: function() {},
+    heartbeat_delay: heartbeatDelay,
+    disconnect_delay: disconnectDelay
   });
 
   var robust = new RobustSockJS();

--- a/lib/router/config-router.js
+++ b/lib/router/config-router.js
@@ -108,6 +108,21 @@ function ConfigRouter(conf, schedulerRegistry) {
   this.$allowAppOverride = conf.getValues('allow_app_override').enabled;
   this.$templateDir = conf.getValues('template_dir').dir;
 
+  this.httpKeepaliveTimeout = 45 * 1000;
+  if (conf.getOne('http_keepalive_timeout')) {
+    this.httpKeepaliveTimeout = conf.getValues('http_keepalive_timeout').timeout * 1000;
+  }
+
+  this.sockjsHeartbeatDelay = 25 * 1000;
+  if (conf.getOne('sockjs_heartbeat_delay')) {
+    this.sockjsHeartbeatDelay = conf.getValues('sockjs_heartbeat_delay').delay * 1000;
+  }
+
+  this.sockjsDisconnectDelay = 5 * 1000;
+  if (conf.getOne('sockjs_disconnect_delay')) {
+    this.sockjsDisconnectDelay = conf.getValues('sockjs_disconnect_delay').delay * 1000;
+  }
+
   var apps = conf.search("application", true);
   if (apps && apps.length > 0){
     logger.error("The `application` configuration has been deprecated. Please "+ 


### PR DESCRIPTION
A user reported disconnects when users on **slow internet connections** try to use apps that have **large outputs** (it's unrelated to how long the outputs take to calculate, it's purely the payload size that matters).

### Repro

I was able to repro using the following app, plus using commands to slow down the network interface on Linux:

```r
library(shiny)

ui <- fluidPage(
  "Hello",
  plotOutput("plot")
)

server <- function(input, output, session) {
  session$sendCustomMessage("test", 1:3E6)
  output$plot <- renderPlot(plot(cars))
}

shinyApp(ui, server)
```

This app sends a ~22MB payload to the client (which is ignored) before rendering the plot.

Run this command on the server to slow down one of the network interfaces (tested on Ubuntu):

```bash
sudo tc qdisc add dev <network-interface> root netem delay 1000ms
```

(Replace <network-interface> with your interface name, e.g. `eth0`. If you don't know your network interface names, call ifconfig. Don't use the `lo` interface, that's the loopback and affects not only client-to-SS communications but also SS-to-R, which seems to result in a different failure mode.)

To turn off the network interface slowness use this command:

```bash
sudo tc qdisc del dev <network-interface> root netem
```

Because we are not using the loopback adapter, you have to use a browser that's on a different machine (or if you're using a Linux VM, then a browser on the host OS will do).

You will get different results depending on what SockJS transport you use:

* websocket: The entire payload is downloaded, but then sockjs-client immediately disconnects with a code 3000 and message "No response from heartbeat". Client does not attempt to reconnect.
* xhr-streaming/xhr-polling: `ERR_INCOMPLETE_CHUNKED_ENCODING` after 45-50 seconds, I believe. Client then attempts to auto-reconnect but the session is gone.

I didn't test any other transports.

### Root cause

There are several different timeouts that work in concert to disrupt this scenario. However, the bottom line is that SockJS was not designed for large amounts of latency in messages being received. There is [an issue filed against sockjs-node](https://github.com/sockjs/sockjs-node/issues/95) that points to the underlying problem, which I'll describe.

From the server side, SockJS needs to know when a client connection is dead, so it can close resources that it's holding from the server side and let the application know it should execute whatever end-of-session logic it has. With xhr-streaming and xhr-polling, this obviously requires a timeout in some way; because the client will serially issue multiple xhr-streaming or (especially) xhr-polling requests over the course of a single connection, there are bound to be times when one request has ended and we're not sure whether another one is ever going to arrive. SockJS has a `disconnect_delay` option that lets you control how long to wait, the default is 5 seconds. This means that when the client ends an xhr-streaming/xhr-polling request, by default it has to issue a new request with 5 seconds or else it will be considered disconnected.

The problem is that the 5 second timer begins not when the current request disconnects, but when the last (asynchronous) message send begins. So if that message takes a long time to deliver, as in this case, the timer will have long since expired even if the client quickly starts a new xhr request.

With websockets, there's one continuous socket the whole time, so there isn't this particular problem. However, there's (apparently) a similar situation, where the client may have gone away but we never got a TCP `FIN` or `RST` or whatever; SockJS wants to know in a timely manner when this situation has occurred. The websocket transport is unique among the transport types in that when a heartbeat packet is sent from server to client (by default every 25 seconds), there is a [hardcoded time limit of 10 seconds](https://github.com/sockjs/sockjs-node/blob/61bba467d9d6b980a651070ed563f59d812e824e/src/trans-websocket.coffee#L94-L105) by which the client must acknowledge the heartbeat by sending a message back to the server. Similar to the xhr problem, this 10 second timer starts when the heartbeat is queued, not when it makes it to the client; and in our repro case above, it's going to be a couple of minutes between when the heartbeat is queued and when it is delivered.

Finally, there's one more timeout that affects the scenario above. In main.js we were calling `socket.setTimeout(45*1000)` on every HTTP request we receive. This was intended to be an http keepalive timeout, so idle sockets don't stay connected to us too long. However, this timeout doesn't seem to work the way I expected; it terminates 45 seconds after data is written to the socket object, regardless of how long it takes for the data to actually be sent. (It was hard to find the right Node.js issue for this problem as there seems to be some different bugged behavior that used to happen when you use the http library on top, but this seems like it may be it: https://github.com/nodejs/node/issues/3319)

### Workaround

This pull request merely lets the admin configure these timeouts by hand. Whatever the longest payload-delivery is expected, at least that number of seconds should be set for `sockjs_disconect_delay`. And `http_keepalive_timeout` should be that number plus another buffer, like 20% or 20 seconds, whichever is less.

Also, `disable_websockets on;` should be used, since the heartbeat response timeout for websockets is hardcoded and can't be changed.

For the repro above, this works for me:

```
http_keepalive_timeout 220;
sockjs_disconnect_delay 200;
disable_websockets;
```

### Potential future work

* `response#end` and `socket#write` both have callbacks that, in this test case at least, fire when the data is fully sent on the socket (so in this case, 2 minutes after write). So it seems like it'd be possible to implement the `http_keepalive_timeout` the "right" way, by monkeypatching the socket's `write` and `setTimeout` methods.
* It would similarly be possible to fire the disconnect timers in SockJS at the right time, but would definitely require some deep understanding of how SockJS works (I have spent some time looking already, and it wasn't obvious to me how to fix it without pretty big changes).
* It'd be nice if SockJS websocket heartbeat response timer was configurable, or disable-able. That seems simple enough.

In multiple conversations with @trestletech and now @jmcphers we've questioned whether SockJS and websockets in general are worth the trouble, given how smoothly RStudio's long-polling works. They might not be, and switching to long-polling would be much simpler and give us much more control over these kinds of issues. However, there is the big disadvantage for SS/SSP that the number of outstanding long-polling requests you can have open to a single hostname are quite limited (usually 6), while the limit for WebSockets is much larger (like 255). It may be that HTTP/2 will solve this problem for us, seems worth investigating.