### PR TITLE
Refactor of scheduler

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,12 +1,14 @@
 shiny-server 1.5.4
 --------------------------------------------------------------------------------
 
-* Upgrade to Node.js v6.10.2
+* Upgrade to Node.js v6.10.2.
+
+* Refactor scheduler code to make enforcement of connection limits more robust.
 
 shiny-server 1.5.3
 --------------------------------------------------------------------------------
 
-* Upgrade to Node.js v6.10.0
+* Upgrade to Node.js v6.10.0.
 
 shiny-server 1.5.2
 --------------------------------------------------------------------------------

--- a/lib/core/url-util.js
+++ b/lib/core/url-util.js
@@ -1,0 +1,17 @@
+/*
+ * url-util.js
+ *
+ * Copyright (C) 2009-13 by RStudio, Inc.
+ *
+ * This program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+function isAppPagePath(path) {
+  return path && (path === "/" || path.match(/\.rmd$/i));
+}
+exports.isAppPagePath = isAppPagePath;

--- a/lib/proxy/http.js
+++ b/lib/proxy/http.js
@@ -21,6 +21,7 @@ var AppSpec = require('../worker/app-spec');
 var fsutil = require('../core/fsutil');
 var render = require('../core/render');
 var shutdown = require('../core/shutdown');
+var url_util = require('../core/url-util');
 
 var error404 = render.error404;
 var errorAppOverloaded = render.errorAppOverloaded;
@@ -130,14 +131,17 @@ function ShinyProxy(router, schedulerRegistry) {
         req.url = '/' + req.url;
       // TODO: Also strip path members
 
+      // Extract the non-param portion of the URL
+      const pathname = req.url.match(/([^\?]+)(\?.*)?/)[1];
+      const isAppPage = !worker && url_util.isAppPagePath(pathname);
+
       //TODO: clean this up. This should be a part of the promise chain, but
       // when returning an error, it would just crash as an unhandled excptn
       // and never make it into the .fail().
       var wrk;
       try{
         // Launch a new, or reuse an existing, R process for this app.
-        // Extract the non-param portion of the URL
-        wrk = schedulerRegistry.getWorker(appSpec, req.url.match(/([^\?]+)(\?.*)?/)[1], worker);
+        wrk = schedulerRegistry.getWorker(appSpec, pathname, worker);
       }
       catch(err){
         if (err instanceof OutOfCapacityError){
@@ -150,14 +154,30 @@ function ShinyProxy(router, schedulerRegistry) {
 
       // Ensures that the worker process will not be reaped while we use it.
       wrk.acquire("http");
-      // Save a reference to the appWorkerHandle on the response so that we
-      // can call appWorkerHandle.release() when the request ends.
-      res.appWorkerEntry = wrk;
+      if (isAppPage) {
+        wrk.acquire("pending");
+      }
+
+      const cleanup = _.once(function() {
+        wrk.release("http");
+        if (isAppPage) {
+          if (!res.proxySuccess) {
+            // The app page request didn't succeed. There won't be a session
+            // starting soon as a result of this HTTP request/response.
+            wrk.release("pending");
+          } else {
+            // We should reasonably expect a session to be starting soon.
+            // Start a timer in case the session doesn't arrive.
+            wrk.pushPendingReleaseTimer(45 * 1000);
+          }
+        }
+      });
+      res.on("finish", cleanup);
+      res.on("close", cleanup);
 
       wrk.getAppWorkerHandle_p().then(function(appWorkerHandle) {
         if (!req.socket.writable) {
           logger.debug("Socket closed, ignoring appWorkerHandle and returning");
-          cleanupResponse(res);
           return;
         }
 
@@ -188,7 +208,6 @@ function ShinyProxy(router, schedulerRegistry) {
         req.resume();
       })
       .fail(function(err) {
-        cleanupResponse(res);
         logger.info('Error getting worker: ' + err);
         if (err.code === 'ENOTFOUND')
           error404(req, res, appSpec.settings.templateDir);
@@ -206,18 +225,6 @@ function ShinyProxy(router, schedulerRegistry) {
     })
     .done();
   };
-
-  /**
-   * Very important that this is called on every response that we've even
-   * begun attempting to proxy; it ensures that the R process can be
-   * released when idle.
-   */
-  function cleanupResponse(response) {
-    if (response.appWorkerEntry){
-      response.appWorkerEntry.release('http');
-    }
-    delete response.appWorkerEntry;
-  }
 
   // Create an HTTP proxy object for the given socket; we need one of these per
   // active socket. node-http-proxy has a RoutingProxy that provides a more
@@ -256,6 +263,7 @@ function ShinyProxy(router, schedulerRegistry) {
       proxyReq.setHeader("connection", "close");
     });
     proxy.on('proxyRes', function(proxyRes, req, res) {
+      res.proxySuccess = proxyRes.statusCode && proxyRes.statusCode >= 200 && proxyRes.statusCode < 300;
       res.setHeader("connection", req.keepalive ? 'keep-alive' : 'close');
     });
 
@@ -264,17 +272,17 @@ function ShinyProxy(router, schedulerRegistry) {
       // if the upstream server drops the connection.
       error500(req, res, 'The application exited unexpectedly.', err.message,
           req.templateDir, appWorkerHandle.logFilePath, appWorkerHandle.appSpec);
-      cleanupResponse(res);
     });
-    // This happens if the proxy-to-target request is disconnected. One easy way
-    // to trigger this, as of this writing, is to have an app.R that has a
-    // Sys.sleep(120) in ui.R.
-    proxy.on('econnreset', function(err, req, res) {
-      cleanupResponse(res);
-    });
-    proxy.on('end', function(req, res) {
-      cleanupResponse(res);
-    });
+    // econnreset happens if the browser-to-proxy request is disconnected.
+    // One easy way to trigger this, as of this writing, is to have an app.R
+    // that has a Sys.sleep(120) in ui.R. This will cause the socket timeout
+    // of 45sec (by default) to be exceeded.
+    //
+    // proxy.on('econnreset', function(err, req, res) {
+    // });
+
+    // proxy.on('end', function(req, res) {
+    // });
     return proxy;
   }
 };

--- a/lib/proxy/http.js
+++ b/lib/proxy/http.js
@@ -135,9 +135,9 @@ function ShinyProxy(router, schedulerRegistry) {
       // and never make it into the .fail().
       var wrk;
       try{
+        // Launch a new, or reuse an existing, R process for this app.
         // Extract the non-param portion of the URL
-        wrk = schedulerRegistry.getWorker_p(appSpec, req.url.match(/([^\?]+)(\?.*)?/)[1], 
-        worker)
+        wrk = schedulerRegistry.getWorker(appSpec, req.url.match(/([^\?]+)(\?.*)?/)[1], worker);
       }
       catch(err){
         if (err instanceof OutOfCapacityError){
@@ -148,23 +148,18 @@ function ShinyProxy(router, schedulerRegistry) {
         throw err;
       }
 
-      var acquired = false;
-      // Launch a new, or reuse an existing, R process for this app.
-      wrk
-      .then(function(appWorkerHandle) {
+      // Ensures that the worker process will not be reaped while we use it.
+      wrk.acquire("http");
+      // Save a reference to the appWorkerHandle on the response so that we
+      // can call appWorkerHandle.release() when the request ends.
+      res.appWorkerEntry = wrk;
 
+      wrk.getAppWorkerHandle_p().then(function(appWorkerHandle) {
         if (!req.socket.writable) {
           logger.debug("Socket closed, ignoring appWorkerHandle and returning");
+          cleanupResponse(res);
           return;
         }
-
-        // Ensures that the worker process will not be reaped while we use it.
-        appWorkerHandle.acquire('http');
-        acquired = true;
-
-        // Save a reference to the appWorkerHandle on the response so that we
-        // can call appWorkerHandle.release() when the request ends.
-        res.appWorkerHandle = appWorkerHandle;
 
         if (!appWorkerHandle.proxy) {
           // Cache an HTTP proxy right on the appWorkerHandle.
@@ -193,9 +188,7 @@ function ShinyProxy(router, schedulerRegistry) {
         req.resume();
       })
       .fail(function(err) {
-        if (acquired){
-          cleanupResponse(res);
-        }
+        cleanupResponse(res);
         logger.info('Error getting worker: ' + err);
         if (err.code === 'ENOTFOUND')
           error404(req, res, appSpec.settings.templateDir);
@@ -207,6 +200,7 @@ function ShinyProxy(router, schedulerRegistry) {
       .done();
     })
     .fail(function(err){
+      logger.error(err);
       error500(req, res, 'Invalid application configuration.', err.message, 
         req.templateDir);
     })
@@ -219,10 +213,10 @@ function ShinyProxy(router, schedulerRegistry) {
    * released when idle.
    */
   function cleanupResponse(response) {
-    if (response.appWorkerHandle){
-      response.appWorkerHandle.release('http');
+    if (response.appWorkerEntry){
+      response.appWorkerEntry.release('http');
     }
-    delete response.appWorkerHandle;
+    delete response.appWorkerEntry;
   }
 
   // Create an HTTP proxy object for the given socket; we need one of these per

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -102,9 +102,6 @@ function createServer(router, schedulerRegistry, heartbeatDelay, disconnectDelay
     // The connection to the worker process.
     var wsClient = null;
 
-    // Represents the worker process.
-    var appWorkerEntry = null;
-
     // Buffer queue for any events that arrive on the SockJS connection before
     // the worker websocket connection has been established.
     var connEventQueue = [];
@@ -116,11 +113,6 @@ function createServer(router, schedulerRegistry, heartbeatDelay, disconnectDelay
 
     conn.on('data', connDataHandler);
     conn.on('close', function() {
-      // Must, must, must match up acquire() and release() calls.
-      if (appWorkerEntry) {
-        appWorkerEntry.release('sock');
-        appWorkerEntry = null;
-      }
       if (wsClient) {
         wsClient.close();
       }
@@ -143,8 +135,22 @@ function createServer(router, schedulerRegistry, heartbeatDelay, disconnectDelay
       }
       throw err;
     }
+
+    // In the common case, a SockJS connection is requested because of an HTTP
+    // request to a top-level app page, and that HTTP request incremented the
+    // pending connection count (wrk.acquire("pending")) in anticipation of
+    // this connection. A pending conn is essentially a reservation for a sock
+    // conn; now that the sock conn has arrived, we can/must release the
+    // reservation.
+    wrk.shiftPendingReleaseTimer();
+    wrk.release("pending");
+
     wrk.acquire("sock");
-    appWorkerEntry = wrk;
+    conn.on("close", _.once(() => {
+      // Must, must, must match up acquire() and release() calls.
+      wrk.release('sock');
+    }));
+
     wrk.getAppWorkerHandle_p().then(function(appWorkerHandle) {
       if (conn.readyState >= 2) // closing or closed
         return;

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -103,7 +103,7 @@ function createServer(router, schedulerRegistry, heartbeatDelay, disconnectDelay
     var wsClient = null;
 
     // Represents the worker process.
-    var appWorkerHandle = null;
+    var appWorkerEntry = null;
 
     // Buffer queue for any events that arrive on the SockJS connection before
     // the worker websocket connection has been established.
@@ -117,9 +117,9 @@ function createServer(router, schedulerRegistry, heartbeatDelay, disconnectDelay
     conn.on('data', connDataHandler);
     conn.on('close', function() {
       // Must, must, must match up acquire() and release() calls.
-      if (appWorkerHandle) {
-        appWorkerHandle.release('sock');
-        appWorkerHandle = null;
+      if (appWorkerEntry) {
+        appWorkerEntry.release('sock');
+        appWorkerEntry = null;
       }
       if (wsClient) {
         wsClient.close();
@@ -134,7 +134,7 @@ function createServer(router, schedulerRegistry, heartbeatDelay, disconnectDelay
     try{
       // Can't specify the URL that we're requesting, so provide 'ws' to
       // represent that this request is for a web socket.
-      wrk = schedulerRegistry.getWorker_p(appSpec, 'ws');
+      wrk = schedulerRegistry.getWorker(appSpec, 'ws');
     }
     catch(err){
       if (err instanceof OutOfCapacityError){
@@ -143,13 +143,11 @@ function createServer(router, schedulerRegistry, heartbeatDelay, disconnectDelay
       }
       throw err;
     }
-    wrk
-    .then(function(awh) {
+    wrk.acquire("sock");
+    appWorkerEntry = wrk;
+    wrk.getAppWorkerHandle_p().then(function(appWorkerHandle) {
       if (conn.readyState >= 2) // closing or closed
         return;
-
-      appWorkerHandle = awh;
-      appWorkerHandle.acquire('sock');
 
       var wsUrl = 'ws://127.0.0.1/';
       var pathInfo = conn.url.substring(appSpec.prefix.length);

--- a/lib/scheduler/scheduler-registry.js
+++ b/lib/scheduler/scheduler-registry.js
@@ -63,7 +63,7 @@ module.exports = SchedulerRegistry;
    *   targetting. If left blank, an arbitrary worker will be selected. Ignored
    *   when using the SimpleScheduler.
    */
-  this.getWorker_p = function(appSpec, url, worker) {
+  this.getWorker = function(appSpec, url, worker) {
     var key = appSpec.getKey();
     if (!this.$schedulers[key]){
       //no scheduler, instantiate a simple scheduler
@@ -72,9 +72,9 @@ module.exports = SchedulerRegistry;
       if (this.$transport){
         this.$schedulers[key].setTransport(this.$transport);
       }
-    }  
+    }
     
-    return this.$schedulers[key].acquireWorker_p(appSpec, url, worker); 
+    return this.$schedulers[key].acquireWorker(appSpec, url, worker); 
   };
 
   this.shutdown = function() {

--- a/lib/scheduler/scheduler.js
+++ b/lib/scheduler/scheduler.js
@@ -10,24 +10,24 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-var child_process = require('child_process');
-var crypto = require('crypto');
-var fs = require('fs');
-var os = require('os');
-var events = require('events');
-var net = require('net');
-var map = require('../core/map');
-var crypto = require('crypto');
-var path = require('path');
-var moment = require('moment');
-var util = require('util');
-var Q = require('q');
-var _ = require('underscore');
+const child_process = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const events = require('events');
+const net = require('net');
+const map = require('../core/map');
+const path = require('path');
+const moment = require('moment');
+const util = require('util');
+const Q = require('q');
+const _ = require('underscore');
 require('../core/log');
-var fsutil = require('../core/fsutil');
-var AppWorkerHandle = require('../worker/app-worker-handle');
-var app_worker = require('../worker/app-worker');
-var posix = require('../../build/Release/posix');
+const fsutil = require('../core/fsutil');
+const AppWorkerHandle = require('../worker/app-worker-handle');
+// can't use const for app_worker because test/scheduler.js uses rewire to mock
+let app_worker = require('../worker/app-worker');
+const posix = require('../../build/Release/posix');
+const WorkerEntry = require('./worker-entry');
 
 /**
  * @param appSpec the appSpec associated
@@ -119,28 +119,26 @@ function connectEndpoint_p(endpoint, timeout, shouldContinue) {
    * allocate a request to it. This is needed to maintain a proper count of
    * how many connections are active for a worker.
    */
-  this.spawnWorker_p = function(appSpec, workerData, preemptive){
+  this.spawnWorker = function(appSpec, workerData, preemptive){
     var self = this;
-
-    // Because appSpec will no longer uniquely identify a worker, assign a
-    // random ID to each worker for addressing purposes.
-    var workerId = crypto.randomBytes(8).toString('hex');
 
     var defer = Q.defer();
 
-    this.$workers[workerId] = { 
-      promise : defer.promise, 
-      data : workerData || map.create()
+    var idleTimeout = 5 * 1000;
+    if (appSpec.settings.appDefaults && (appSpec.settings.appDefaults.idleTimeout || appSpec.settings.appDefaults.idleTimeout === 0)){
+      idleTimeout = appSpec.settings.appDefaults.idleTimeout * 1000;
+
+      if (idleTimeout > Math.pow(2,31) - 1) {
+        // Node currently only supports 32-bit setTimeouts
+        // http://stackoverflow.com/questions/16314750/settimeout-fires-immediately-if-the-delay-more-than-2147483648-milliseconds
+        logger.warn('Idle timeout value "' + appSpec.settings.appDefaults.idleTimeout + '" too high. Using the maximum of 2147483 seconds instead. Consider using a negative value if you want to disable the timeout altogether.');
+        idleTimeout = Math.pow(2,31) - 1;
+      }
     }
 
-    let data = this.$workers[workerId].data;
-    //initialize open connections counters.
-    data.sockConn = 0;
-    data.httpConn = 0;
-    data.pendingConn = 0;
-    if (!preemptive){
-      data.pendingConn++;
-    }
+    let workerEntry = new WorkerEntry(defer.promise, workerData || map.create(), idleTimeout);
+    let workerId = workerEntry.id;
+    this.$workers[workerId] = workerEntry;
 
     var logFilePath = null;
     var doReject = function(err) {
@@ -177,6 +175,9 @@ function connectEndpoint_p(endpoint, timeout, shouldContinue) {
       var exitPromise = workerPromise.invoke('getExit_p');
       exitPromise
       .fin(function() {
+        if (self.$workers[workerId]) {
+          self.$workers[workerId].close();
+        }
         delete self.$workers[workerId];
         if (_.size(self.$workers) === 0) {
           // There aren't any workers left, kill this scheduler.
@@ -224,6 +225,20 @@ function connectEndpoint_p(endpoint, timeout, shouldContinue) {
           logFilePath, exitPromise,
           _.bind(appWorker.kill, appWorker));
 
+        workerEntry.on("idletimeout", () => {
+          logger.trace("Timeout expired. Killing process.");
+          deleteLogFileOnExit = true;
+          if (!appWorker.isRunning()) {
+            logger.trace('Process on ' + endpoint.toString() + ' is already gone');
+          } else {
+            logger.trace('Interrupting process on socket ' + endpoint.toString());
+            try {
+              appWorker.kill();
+            } catch (err) {
+              logger.error('Failed to kill process on ' + endpoint.toString() + ': ' + err.message);
+            }
+          }
+        });
 
         var initTimeout = 60 * 1000;
         if (appSpec.settings.appDefaults && appSpec.settings.appDefaults.initTimeout){
@@ -235,102 +250,9 @@ function connectEndpoint_p(endpoint, timeout, shouldContinue) {
 
         connectPromise
         .then(function() {
-          /**
-           * Supplement the workerHandle with acquire and release functions.
-           */
-          (function() {
-            this.acquire = function(type){
-              let workerData = self.$workers[workerId].data;
-              if(type == 'http'){
-                workerData.httpConn++;
-              } else if(type == 'sock'){
-                workerData.sockConn++;
-              } else{
-                throw Error('Unrecognized type to be acquired: "' + type + '"');
-              }
-
-              //We just realized a pending connection. Decrement the counter.
-              if (workerData.pendingConn > 0){
-                workerData.pendingConn--;
-              }
-
-              logger.trace('Worker #'+workerId+' acquiring '+type+' port. ' + 
-                workerData.httpConn + ' open HTTP connection(s), ' +
-                workerData.sockConn + ' open WebSocket connection(s).')
-
-              //clear the timer to ensure this process doesn't get destroyed.
-              var timerId = workerData.timer;
-              if (timerId){
-                clearTimeout(timerId);                
-                workerData.timer = null;
-              }              
-            };
-            
-            var idleTimeout = 5 * 1000;
-            if (appSpec.settings.appDefaults && (appSpec.settings.appDefaults.idleTimeout || appSpec.settings.appDefaults.idleTimeout === 0)){
-              idleTimeout = appSpec.settings.appDefaults.idleTimeout * 1000;
-
-              if (idleTimeout > Math.pow(2,31) - 1) {
-                // Node currently only supports 32-bit setTimeouts
-                // http://stackoverflow.com/questions/16314750/settimeout-fires-immediately-if-the-delay-more-than-2147483648-milliseconds
-                logger.warn('Idle timeout value "' + appSpec.settings.appDefaults.idleTimeout + '" too high. Using the maximum of 2147483 seconds instead. Consider using a negative value if you want to disable the timeout altogether.');
-                idleTimeout = 2147483;
-              }
-            }
-
-            this.release = function(type){
-              if (!_.has(self.$workers, workerId)){
-                // Must have already been deleted. Don't need to do any work.
-                return;
-              }
-
-              let workerData = self.$workers[workerId].data;
-              if(type == 'http'){
-                workerData.httpConn--;
-                workerData.httpConn = Math.max(0, workerData.httpConn);
-              } else if(type == 'sock'){
-                workerData.sockConn--;
-                workerData.sockConn = Math.max(0, workerData.sockConn);
-              } else{
-                throw Error('Unrecognized type to be released: "' + type + '"');
-              }
-
-              logger.trace('Worker #'+workerId+' releasing '+type+' port. ' + 
-                workerData.httpConn + ' open HTTP connection(s), ' +
-                workerData.sockConn + ' open WebSocket connection(s).')
-              
-              if (workerData.sockConn + workerData.httpConn === 0) {
-                if (idleTimeout > 0){
-                  logger.trace("No clients connected to worker #" + workerId + ". Starting timer");
-                  workerData.timer = global.setTimeout(function() {
-                    logger.trace("Timeout expired. Killing process.");
-                    deleteLogFileOnExit = true;
-                    if (!appWorker.isRunning()) {
-                      logger.trace('Process on ' + endpoint.toString() + ' is already gone');
-                    } else {
-                      logger.trace('Interrupting process on socket ' + endpoint.toString());
-                      try {
-                        appWorker.kill();
-                      } catch (err) {
-                        logger.error('Failed to kill process on ' + endpoint.toString() + ': ' + err.message);
-                      }
-                    }
-                  }, idleTimeout);
-                }
-                else {
-                  logger.trace("No clients connected to worker #" + workerId + ", but refusing to reap due to non-positive idle_timeout.");
-                }
-              }
-            
-            };
-
-          }).call(appWorkerHandle);
-
-          // Call release initially. This won't change the value of the counter, 
-          // as they have a minimum of 0, but it will trigger a timer to ensure
-          // that this worker doesn't spin up, never get used, and run 
-          // indefinitely.
-          appWorkerHandle.release('http');
+          // Trigger the idle timer to ensure that this worker doesn't spin up,
+          // never get used, and run indefinitely.
+          workerEntry.startIdleTimer();
 
           return defer.resolve(appWorkerHandle);
           },
@@ -349,7 +271,7 @@ function connectEndpoint_p(endpoint, timeout, shouldContinue) {
     })
     .done();
 
-    return defer.promise;
+    return workerEntry;
   };
 
   this.getLogFilePath = function(appSpec, endpoint) {

--- a/lib/scheduler/simple-scheduler.js
+++ b/lib/scheduler/simple-scheduler.js
@@ -44,14 +44,17 @@ util.inherits(SimpleScheduler, Scheduler);
 	      		hardLimit = Infinity;
 	      	} 
 
-	      	var conns = thisWorker.data.sockConn;
+	      	var conns = thisWorker.sessionCount();
 
 	      	if (conns < hardLimit){
 	      		// We have room for at least 1 more request
 	      		return thisWorker;
 	      	}
-	      	else if (url != 'ws' && url != '/'){
+	      	else if (url !== 'ws' && url !== '/') {
 	      		// We're not trying to create a new session, fulfill all HTTP traffic.
+	      		return thisWorker;
+	      	}
+	      	else if (url === 'ws' && thisWorker.data.pendingConn > 0 && conns < hardLimit + 1) {
 	      		return thisWorker;
 	      	}
 	      	else {

--- a/lib/scheduler/simple-scheduler.js
+++ b/lib/scheduler/simple-scheduler.js
@@ -31,9 +31,11 @@ util.inherits(SimpleScheduler, Scheduler);
 	 * Defines how this schedule will identify and select an R process to 
 	 * fulfill its requests.
 	 */
-	this.acquireWorker_p = function(appSpec, url){
+	this.acquireWorker = function(appSpec, url){
 	    if (this.$workers && _.size(this.$workers) > 0) {
 	      logger.trace('Reusing existing instance');
+
+	      var thisWorker = this.$workers[_.keys(this.$workers)[0]];
 
 	      if (appSpec.settings.scheduler.simple && 
 	      	appSpec.settings.scheduler.simple.maxRequests){
@@ -42,17 +44,15 @@ util.inherits(SimpleScheduler, Scheduler);
 	      		hardLimit = Infinity;
 	      	} 
 
-	      	var thisWorker = this.$workers[_.keys(this.$workers)[0]];
-	      	var conns = thisWorker.data.sockConn + 
-	      							thisWorker.data.pendingConn;
+	      	var conns = thisWorker.data.sockConn;
 
 	      	if (conns < hardLimit){
 	      		// We have room for at least 1 more request
-	      		return Q.resolve(this.$workers[Object.keys(this.$workers)[0]].promise);
+	      		return thisWorker;
 	      	}
 	      	else if (url != 'ws' && url != '/'){
 	      		// We're not trying to create a new session, fulfill all HTTP traffic.
-	      		return Q.resolve(this.$workers[Object.keys(this.$workers)[0]].promise);
+	      		return thisWorker;
 	      	}
 	      	else {
 	      		throw new OutOfCapacityError("This application cannot handle " + 
@@ -60,12 +60,12 @@ util.inherits(SimpleScheduler, Scheduler);
 	      	}
 	      } else{
 	      	// No limit specified, just direct an unlimited amount of traffic here.
-	      	return Q.resolve(this.$workers[Object.keys(this.$workers)[0]].promise);
+			return thisWorker;
 	      }
 	    }
 
 	    logger.trace('Spawning new instance');
-	    return this.spawnWorker_p(appSpec);
+	    return this.spawnWorker(appSpec);
 	};
 
 }).call(SimpleScheduler.prototype);

--- a/lib/scheduler/worker-entry.js
+++ b/lib/scheduler/worker-entry.js
@@ -44,10 +44,48 @@ class WorkerEntry extends EventEmitter {
     this.data = data;
     this.data.httpConn = 0;
     this.data.sockConn = 0;
+    // See comment for this.pendingReleaseTimers below.
+    this.data.pendingConn = 0;
     this.idleTimeout = idleTimeout;
     // If true, the scheduler has removed this entry from the
     // worker table already and it can no longer be used.
     this.closed = false;
+
+    // The purpose of pendingConn and pendingReleaseTimers requires some
+    // explanation. When we receive an HTTP request for an app page (as
+    // opposed to an HTTP request for a JS/CSS asset or for a subapp page)
+    // or an .Rmd document, we know that if the request is successful it
+    // is a pretty safe bet that a new SockJS connection will soon be on
+    // the way. Therefore, we should essentially "reserve" a spot for that
+    // connection, and that's what pendingConn is; we should increment it
+    // when an app page or Rmd is loaded, and decrement it when a SockJS
+    // connection arrives. (Note that it's just a simple counter, there's
+    // matching up of specific HTTP requests with corresponding SockJS
+    // connections.)
+    //
+    // On the other hand, it's not absolutely guaranteed that a SockJS
+    // connection will actually arrive. There could be proxy or firewall
+    // issues, or JS bugs. If a connection never arrives then pendingConn
+    // is never decremented, and the worker can never be shut down. So
+    // we maintain a FIFO queue of timers (pendingReleaseTimers) that will
+    // decrement pendingConn after a reasonable delay. Each time a SockJS
+    // connection arrives, we should not only decrement pendingConn, but
+    // also kill the first (i.e. oldest) timer in the queue.
+    //
+    // One last thing. It may be an arbitrarily long time between when
+    // the HTTP request for the app page/.Rmd document begins and ends.
+    // During this period, we want to pre-emptively reserve a spot (i.e.
+    // we need to increment pendingConn as request processing begins, not
+    // ends) and if the request fails, then we immediately decrement
+    // pendingConn and don't append a pendingReleaseTimers timer. If we
+    // don't do this, then we may let lots and lots of app pages be
+    // loaded when we couldn't possibly have the capacity to serve their
+    // sessions; better to 503 immediately on the HTTP request.
+    this.pendingReleaseTimers = [];
+  }
+
+  sessionCount() {
+    return this.data.sockConn + this.data.pendingConn;
   }
 
   acquire(connType) {
@@ -55,13 +93,16 @@ class WorkerEntry extends EventEmitter {
       this.data.httpConn++;
     } else if (connType === "sock") {
       this.data.sockConn++;
+    } else if (connType === "pending") {
+      this.data.pendingConn++;
     } else {
       throw Error("Unrecognized type to be acquired: \"" + connType + "\"");
     }
 
     logger.trace("Worker #" + this.id + " acquiring " + connType + " port. " + 
-      this.data.httpConn + " open HTTP connection(s), " +
-      this.data.sockConn + " open WebSocket connection(s).");
+      this.data.httpConn + " HTTP, " +
+      this.data.sockConn + " WebSocket, " +
+      this.data.pendingConn + " pending.");
 
     // clear the timer to ensure this process doesn't get destroyed.
     if (this.timer) {
@@ -80,25 +121,33 @@ class WorkerEntry extends EventEmitter {
       return;
     }
 
-    if (connType == "http") {
+    if (connType === "http") {
       this.data.httpConn--;
       this.data.httpConn = Math.max(0, this.data.httpConn);
-    } else if (connType == "sock") {
+    } else if (connType === "sock") {
       this.data.sockConn--;
       this.data.sockConn = Math.max(0, this.data.sockConn);
+    } else if (connType === "pending") {
+      if (this.data.pendingConn <= 0) {
+        logger.trace("Worker #" + this.id + " released pending but none " +
+            "were available.");
+        return;
+      }
+      this.data.pendingConn--;
     } else {
       throw Error("Unrecognized type to be released: \"" + connType + "\"");
     }
 
     logger.trace("Worker #" + this.id + " releasing " + connType + " port. " + 
-      this.data.httpConn + " open HTTP connection(s), " +
-      this.data.sockConn + " open WebSocket connection(s).")
+      this.data.httpConn + " HTTP, " +
+      this.data.sockConn + " WebSocket, " +
+      this.data.pendingConn + " pending.");
 
     this.startIdleTimer();
   }
 
   startIdleTimer() {
-    if (this.data.sockConn + this.data.httpConn === 0) {
+    if (this.data.sockConn + this.data.httpConn + this.data.pendingConn === 0) {
       if (this.idleTimeout > 0){
         logger.trace("No clients connected to worker #" + this.id + ". Starting timer");
         global.clearTimeout(this.timer);
@@ -112,8 +161,33 @@ class WorkerEntry extends EventEmitter {
     }    
   }
 
+  // Create a new timer to call release("pending") after a delay, and
+  // push the timer onto a list. See also shiftPendingReleaseTimer.
+  pushPendingReleaseTimer(timeout) {
+    const timerId = global.setTimeout(() => {
+      if (this.closed) return;
+
+      logger.trace("Worker #" + this.id + " pending session timer expired");
+      this.release("pending");
+    }, timeout);
+    this.pendingReleaseTimers.push(timerId);
+  }
+
+  // Cancel the oldest timer in the pendingReleaseTimers list.
+  // Returns true if a pendingReleaseTimer was in the queue.
+  shiftPendingReleaseTimer() {
+    if (this.pendingReleaseTimers.length > 0) {
+      global.clearTimeout(this.pendingReleaseTimers.shift());
+      return true;
+    }
+    return false;
+  }
+
   close() {
     this.closed = true;
+    while (this.shiftPendingReleaseTimer()) {
+      // intentionally empty
+    }
   }
 }
 module.exports = WorkerEntry;

--- a/lib/scheduler/worker-entry.js
+++ b/lib/scheduler/worker-entry.js
@@ -165,6 +165,12 @@ class WorkerEntry extends EventEmitter {
   // push the timer onto a list. See also shiftPendingReleaseTimer.
   pushPendingReleaseTimer(timeout) {
     const timerId = global.setTimeout(() => {
+      if (this.pendingReleaseTimers.length > 0 && this.pendingReleaseTimers[0] === timerId) {
+        this.pendingReleaseTimers.shift();
+      } else {
+        logger.warn("Surprisingly, active pending release timer wasn't on the front of the queue");
+      }
+
       if (this.closed) return;
 
       logger.trace("Worker #" + this.id + " pending session timer expired");

--- a/lib/scheduler/worker-entry.js
+++ b/lib/scheduler/worker-entry.js
@@ -1,0 +1,119 @@
+/*
+ * worker-entry.js
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * This program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+const crypto = require("crypto");
+var EventEmitter = require('events');
+require('../core/log');
+
+/**
+ * An entry in the worker table in Scheduler. This provides:
+ * 
+ * 1. A set of counters, for how many active http and sockjs connections have
+ *    been assigned to this worker process.
+ *
+ *    a. acquire/release methods for incrementing/decrementing the connection
+ *       count.
+ *
+ * 2. The (promise to the) AppWorkerHandle object for this process. It is
+ *    possible for the process to be launched but fail during startup (i.e. it
+ *    never starts listening for connections on the expected port before either
+ *    exiting or timing out (app_init_timeout)), in which case the promise will
+ *    be rejected.
+ *
+ * 3. An "idletimeout" event which will fire after the worker has been unused
+ *    for idleTimeout milliseconds (specified by app_idle_timeout).
+ *
+ * 4. An id field which uniquely identifies this worker.
+ */
+class WorkerEntry extends EventEmitter {
+  constructor(promise, data, idleTimeout) {
+    super();
+    // Because appSpec will no longer uniquely identify a worker, assign a
+    // random ID to each worker for addressing purposes.
+    this.id = crypto.randomBytes(8).toString('hex');
+    this.promise = promise;
+    this.data = data;
+    this.data.httpConn = 0;
+    this.data.sockConn = 0;
+    this.idleTimeout = idleTimeout;
+    // If true, the scheduler has removed this entry from the
+    // worker table already and it can no longer be used.
+    this.closed = false;
+  }
+
+  acquire(connType) {
+    if (connType === "http") {
+      this.data.httpConn++;
+    } else if (connType === "sock") {
+      this.data.sockConn++;
+    } else {
+      throw Error("Unrecognized type to be acquired: \"" + connType + "\"");
+    }
+
+    logger.trace("Worker #" + this.id + " acquiring " + connType + " port. " + 
+      this.data.httpConn + " open HTTP connection(s), " +
+      this.data.sockConn + " open WebSocket connection(s).");
+
+    // clear the timer to ensure this process doesn't get destroyed.
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  getAppWorkerHandle_p() {
+    return this.promise;
+  }
+
+  release(connType) {
+    if (this.closed) {
+      // Must have already been deleted. Don't need to do any work.
+      return;
+    }
+
+    if (connType == "http") {
+      this.data.httpConn--;
+      this.data.httpConn = Math.max(0, this.data.httpConn);
+    } else if (connType == "sock") {
+      this.data.sockConn--;
+      this.data.sockConn = Math.max(0, this.data.sockConn);
+    } else {
+      throw Error("Unrecognized type to be released: \"" + connType + "\"");
+    }
+
+    logger.trace("Worker #" + this.id + " releasing " + connType + " port. " + 
+      this.data.httpConn + " open HTTP connection(s), " +
+      this.data.sockConn + " open WebSocket connection(s).")
+
+    this.startIdleTimer();
+  }
+
+  startIdleTimer() {
+    if (this.data.sockConn + this.data.httpConn === 0) {
+      if (this.idleTimeout > 0){
+        logger.trace("No clients connected to worker #" + this.id + ". Starting timer");
+        global.clearTimeout(this.timer);
+        this.timer = global.setTimeout(() => {
+          this.emit("idletimeout");
+        }, this.idleTimeout);
+      }
+      else {
+        logger.trace("No clients connected to worker #" + this.id + ", but refusing to reap due to non-positive idle_timeout.");
+      }
+    }    
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+module.exports = WorkerEntry;

--- a/test/scheduler-registry.js
+++ b/test/scheduler-registry.js
@@ -23,7 +23,7 @@ var SchedulerRegistry = rewire('../lib/scheduler/scheduler-registry');
 var SimpleScheduler =  function (eventBus, appSpec, timeout) {
   this.type = "MockSimpleScheduler";
 };
-SimpleScheduler.prototype.acquireWorker_p = function(appSpec, url, worker){
+SimpleScheduler.prototype.acquireWorker = function(appSpec, url, worker){
   return {type: "MockWorker"};
 }
 SchedulerRegistry.__set__("SimpleScheduler", SimpleScheduler);
@@ -41,8 +41,8 @@ var eventBus =  new SimpleEventBus();
 var URL = "/URL";
 var WORKER = "SomeWorker";
 
-// Spy on the acquireWorker_p function.
-var acquireWorkerSpy = sinon.spy(SimpleScheduler.prototype, "acquireWorker_p");
+// Spy on the acquireWorker function.
+var acquireWorkerSpy = sinon.spy(SimpleScheduler.prototype, "acquireWorker");
 
 
 describe('SchedulerRegistry', function(){  
@@ -50,12 +50,12 @@ describe('SchedulerRegistry', function(){
     acquireWorkerSpy.reset();
   })
 
-  describe('#getWorker_p', function(){
+  describe('#getWorker', function(){
     it('Creates a new scheduler on initial request.', function(){
       var schedReg = new SchedulerRegistry(eventBus);
 
       _.size(schedReg.$schedulers).should.equal(0);
-      schedReg.getWorker_p(appSpec, URL, WORKER);
+      schedReg.getWorker(appSpec, URL, WORKER);
       
       // Confirm we created the scheduler in the right place and of the right type.
       _.size(schedReg.$schedulers).should.equal(1);
@@ -68,8 +68,8 @@ describe('SchedulerRegistry', function(){
       var schedReg = new SchedulerRegistry(eventBus);
 
       _.size(schedReg.$schedulers).should.equal(0);
-      schedReg.getWorker_p(appSpec, URL, WORKER);
-      schedReg.getWorker_p(appSpec, URL, WORKER);
+      schedReg.getWorker(appSpec, URL, WORKER);
+      schedReg.getWorker(appSpec, URL, WORKER);
       
       _.size(schedReg.$schedulers).should.equal(1);
       // Confirm we created the scheduler in the right place and of the right type.
@@ -82,7 +82,7 @@ describe('SchedulerRegistry', function(){
       var schedReg = new SchedulerRegistry(eventBus);
 
       _.size(schedReg.$schedulers).should.equal(0);
-      schedReg.getWorker_p(appSpec, URL, WORKER);
+      schedReg.getWorker(appSpec, URL, WORKER);
       _.size(schedReg.$schedulers).should.equal(1);
 
       eventBus.emit('vacantSched', appSpec.getKey());
@@ -98,8 +98,8 @@ describe('SchedulerRegistry', function(){
       }; 
 
       _.size(schedReg.$schedulers).should.equal(0);
-      schedReg.getWorker_p(appSpec, URL, WORKER);
-      schedReg.getWorker_p(alternateAppSpec, URL, WORKER);
+      schedReg.getWorker(appSpec, URL, WORKER);
+      schedReg.getWorker(alternateAppSpec, URL, WORKER);
       
       _.size(schedReg.$schedulers).should.equal(2);
       // Confirm we created the scheduler in the right place and of the right type.


### PR DESCRIPTION
This refactor is intended to simplify the scheduler logic; specifically, to eliminate a gap in resource acquisition tracking when a worker is starting up.

Previously, worker clients like lib/proxy/http.js and lib/proxy/sockjs.js would call getWorker_p, then after the returned promise is successfully resolved with an app worker handle, call acquire() on that handle. The resolution of the promise doesn’t happen until the app has successfully started up (including global.R executing) so it may take a long time. During this window of time, the scheduler has effectively handed out the resource (the worker) but the bookkeeping has not been done yet, since acquire() is not called until later. This gap between resource assignment and bookkeeping is a problem for enforcing resource limits. To mitigate this, there was a `pendingConn` connection count that would track the number of http/sock connections that are expected to happen after startup completes.

This commit modifies the implementation of getWorker_p (and associated underlying functions) to return not a promise to the worker handle, but instead, a new abstraction called a WorkerEntry. This WorkerEntry is returned synchronously and has acquire() and release() methods, as well as a way to retrieve the promise to the worker handle. Callers should call acquire() immediately after getWorker returns, eliminating the bookkeeping gap and thus obsoleting pendingConn.