### PR TITLE
Bookmark state dir was resolving too early

### DIFF
--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -214,7 +214,7 @@ function createBookmarkStateDirectory_p(bookmarkStateDir, username) {
 
   return createDir_p(bookmarkStateDir, '711')
   .then(function() {
-    createDir_p(userBookmarkStateDir, '700', username, 'user');
+    return createDir_p(userBookmarkStateDir, '700', username, 'user');
   })
   .fail(function(err) {
     throw err;


### PR DESCRIPTION
This change prevents `createBookmarkStateDirectory_p` from resolving until both the `bookmarkStateDir` and `userBookmarkStateDir` operations are compete.