### PR TITLE
Some asset URL requests were resulting in 500, not 404

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -168,7 +168,8 @@ app.use(connect_util.filterByRegex(
     function next404() { render.error404(req, res); }
     // Need to trim off the directory, as if we got here via a connect route
     req.originalUrl = req.originalUrl || req.url;
-    req.url = req.url.replace(/^.*\b__assets__\//, '');
+    req.url = req.url.replace(/^.*\b__assets__\//, '')
+      .replace(/^\?/, '/?'); // __assets__/?foo was throwing 500 instead of 404
     if (req.url === 'shiny-server-client.js' || req.url === 'shiny-server-client.min.js') {
       ssjAssets(req, res, next404);
     } else {


### PR DESCRIPTION
e.g. `/__assets__/?foo`

This was due to the URL being shortened to `"?foo"` after we get
rid of `/__assets__/`. Changing it to `"/?foo"` fixes it.