### PR TITLE
Fix "Can't set headers after they are sent" error in logs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@ shiny-server 1.5.4
 
 * Add opt-in clickjacking protection via `frame_options` directive.
 
+* Fix "Error: Can't set headers after they are sent." appearing in the log.
+
 shiny-server 1.5.3
 --------------------------------------------------------------------------------
 

--- a/lib/router/directory-router.js
+++ b/lib/router/directory-router.js
@@ -90,7 +90,7 @@ function DirectoryRouter(root, runas, dirIndex, prefix, logdir, settings,
             'Location': reqUrl.pathname + '/' + (reqUrl.search || '')
           });
           res.end();
-          return false;
+          return true;
         }
         else {
           var appDir = path.join(self.$root, subpath.res.path);
@@ -173,6 +173,7 @@ function DirectoryRouter(root, runas, dirIndex, prefix, logdir, settings,
             .on('error', onError)
             .on('stream', onStream)
             .pipe(res);
+          deferred.resolve(true);
         } else {
           // Either serve up 404, or the directory auto-index
           if (!self.$dirIndex) {


### PR DESCRIPTION
Repro case: Navigate to a Shiny app URL but leave off the trailing /.

The piece of code that detects that is supposed to send a redirect
and then `return true;` to indicate that the request was fully handled;
but instead, it sends the redirect and then `return false;`, which
means that it could not be handled and the next handler should take
a crack at it. The final handler in the chain sends a 404 (i.e.
that's the default behavior if no handlers know what to do with it),
but that fails because the redirect was already sent.