### PR TITLE
Ubuntu Dockerfile: Added dependencies, eased sudo

### DIFF
--- a/docker/ubuntu16.04/Dockerfile
+++ b/docker/ubuntu16.04/Dockerfile
@@ -46,6 +46,9 @@ RUN useradd --create-home --shell /bin/bash docker \
     && passwd docker -d \
     && adduser docker sudo
 
+# Don't require a password for sudo
+RUN sed -i 's/^\(%sudo.*\)ALL$/\1NOPASSWD:ALL/' /etc/sudoers
+
 # =====================================================================
 # Shiny Server dev stuff + Shiny
 # =====================================================================
@@ -59,7 +62,10 @@ RUN apt-get update && apt-get install -y \
     libxt-dev \
     libssl-dev \
     libxml2-dev \
-    cmake
+    cmake \
+    # Pro-specific
+    libpam0g-dev \
+    openjdk-8-jre
 
 # Download and install shiny server
 RUN wget --no-verbose https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/VERSION -O "version.txt" && \


### PR DESCRIPTION
This PR adds some packages needed by the Pro build, but should be harmless ™️ to include here too.

I also added a line of `sed` that fixes up `/etc/sudoers` so that hitting enter isn't necessary after `sudo`. This makes life easier for scripts that use `docker exec` to invoke commands involving `sudo`.