### PR TITLE
Jenkins pipeline builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,14 @@ def prepareWorkspace(){ // accessory to clean workspace and checkout
   sh 'git reset --hard && git clean -ffdx' // lifted from rstudio/connect
 }
 
+def getBucketFromJobName(job) {
+  def bucket = 'rstudio-shiny-server-os-build'
+  if (job.contains('shiny-server-pro')) {
+    bucket = 'rstudio-shiny-server-pro-build'
+  }
+  return bucket
+}
+
 def getPathFromBranch(branch_name) {
   def path = ''
   if (branch_name != 'master') {
@@ -34,10 +42,11 @@ def getPackageTypeFromOs(os) {
 }
 
 def s3_upload(os, arch) {
+  def bucket = getBucketFromJobName(env.JOB_NAME)
   def path = getPathFromBranch(env.BRANCH_NAME)
   def type = getPackageTypeFromOs(os)
-  sh "aws s3 cp packaging/build/*.${type} s3://rstudio-shiny-server-os-build/${path}/${os}/${arch}/"
-  sh "aws s3 cp packaging/build/VERSION s3://rstudio-shiny-server-os-build/${path}/${os}/${arch}/"
+  sh "aws s3 cp packaging/build/*.${type} s3://${bucket}/${path}/${os}/${arch}/"
+  sh "aws s3 cp packaging/build/VERSION s3://${bucket}/${path}/${os}/${arch}/"
 }
 
 try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,69 @@
+#!groovy
+
+properties([
+    disableConcurrentBuilds(),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '',
+                              artifactNumToKeepStr: '',
+                              daysToKeepStr: '',
+                              numToKeepStr: '100')),
+    parameters([string(name: 'SLACK_CHANNEL', defaultValue: '#shiny-server', description: 'Slack channel to publish build message.')])
+])
+
+def prepareWorkspace(){ // accessory to clean workspace and checkout
+  step([$class: 'WsCleanup'])
+  checkout scm
+  sh 'git reset --hard && git clean -ffdx' // lifted from rstudio/connect
+}
+
+try {
+    timestamps {
+        def containers = [
+          [os: 'ubuntu-12.04', arch: 'x86_64'],
+          [os: 'centos5.9', arch: 'x86_64'],
+          [os: 'centos6.3', arch: 'x86_64']
+        ]
+        def parallel_containers = [:]
+        for (int i = 0; i < containers.size(); i++) {
+            def index = i
+            parallel_containers["${containers[i].os}-${containers[i].arch}"] = {
+                def current_container = containers[index]
+                node('docker') {
+                    stage('prepare ws/container'){
+                      prepareWorkspace()
+                      def image_tag = "${current_container.os}-${current_container.arch}"
+                      container = pullBuildPush(image_name: 'jenkins/shiny-server', dockerfile: "docker/jenkins/Dockerfile.${current_container.os}", image_tag: image_tag, build_arg_jenkins_uid: 'JENKINS_UID', build_arg_jenkins_gid: 'JENKINS_GID')
+                    }
+                    container.inside() {
+                        withEnv(["OS=${current_container.os}", "ARCH=${current_container.arch}"]) {
+                          stage('make package'){
+                              sh """
+                              if [ -f ./packaging/make-package-jenkins.sh ]; then
+                                ./packaging/make-package-jenkins.sh
+                                else
+                                ./packaging/make-package.sh
+                              fi
+                              """
+                          }
+                          stage('run tests') {
+                              sh './bin/node ./node_modules/mocha/bin/mocha test'
+                          }
+                          stage('check licenses') {
+                              sh 'tools/preflight.sh'
+                          }
+                        }
+                    }
+                    //stage('s3 upload') {
+                    //    TODO
+                    //}
+                }
+            }
+        }
+        parallel parallel_containers
+
+        sendNotifications slack_channel: SLACK_CHANNEL
+    }
+
+} catch(err) {
+   sendNotifications slack_channel: SLACK_CHANNEL
+   error("failed: ${err}")
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,7 @@ def getPackageTypeFromOs(os) {
   } else {
     type = 'rpm'
   }
+  return type
 }
 
 def s3_upload(os, arch) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,10 +94,12 @@ try {
         }
         parallel parallel_containers
 
-        sendNotifications slack_channel: SLACK_CHANNEL
+        if (env.BRANCH_NAME == 'master') {
+          sendNotifications slack_channel: SLACK_CHANNEL
+        }
     }
 
 } catch(err) {
-   sendNotifications slack_channel: SLACK_CHANNEL
+   sendNotifications slack_channel: SLACK_CHANNEL, result: 'FAILURE'
    error("failed: ${err}")
 }

--- a/docker/jenkins/Dockerfile.centos5.9
+++ b/docker/jenkins/Dockerfile.centos5.9
@@ -37,13 +37,14 @@ RUN wget http://ftp.gnu.org/gnu/wget/wget-1.19.1.tar.gz && \
     ./configure --with-ssl=openssl --with-libssl-prefix=/usr/lib64/openssl --prefix=/usr/local && \
     make && make install
 
-# UPDATE THE CERTS. TRUST THE HAXX.
-RUN wget --no-check-certificate -O /etc/pki/tls/certs/ca-bundle.crt https://curl.haxx.se/ca/cacert.pem
+# update the root ca bundle. no-check-certificate so ugly.
+RUN wget --no-check-certificate -O /usr/local/openssl/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem \
+  && ln -s /usr/local/openssl/certs/ca-bundle.crt /usr/local/openssl/cert.pem
 
 # install cmake
 RUN curl -Lk http://www.cmake.org/files/v2.8/cmake-2.8.10.tar.gz | tar xz && cd cmake-2.8.10 && ./configure && make && make install
 
-RUN wget --no-check-certificate https://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
+RUN wget https://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
 RUN yum -y install devtoolset-2-gcc devtoolset-2-binutils
 RUN yum -y install devtoolset-2-gcc-gfortran devtoolset-2-gcc-c++
 

--- a/docker/jenkins/Dockerfile.centos5.9
+++ b/docker/jenkins/Dockerfile.centos5.9
@@ -1,0 +1,55 @@
+FROM astj/centos5-vault
+MAINTAINER Chad Barraford <chad@rstudio.com>
+
+RUN yum -y update
+RUN yum -y install epel-release
+RUN yum -y groupinstall "Development tools"
+RUN yum -y install rsyslog screen passwd sudo wget git python26 python-setuptools python-devel gcc glibc-devel python-setuptools R curl openssl-devel
+RUN easy_install Mercurial==3.4.2
+
+RUN cd /usr/local/ && \
+    wget -O jdk.tar.gz --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u141-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-8u141-linux-x64.tar.gz" && \
+    tar xzf jdk.tar.gz && \
+    cd /usr/local/jdk1.8.0_141/ && \
+    alternatives --install /usr/bin/java java /usr/local/jdk1.8.0_141/bin/java 2 && \
+    alternatives --install /usr/bin/jar jar /usr/local/jdk1.8.0_141/bin/jar 2 && \
+    alternatives --install /usr/bin/javac javac /usr/local/jdk1.8.0_141/bin/javac 2 && \
+    alternatives --set jar /usr/local/jdk1.8.0_141/bin/jar && \
+    alternatives --set javac /usr/local/jdk1.8.0_141/bin/javac && \
+    rm /usr/local/jdk.tar.gz
+
+# need to run a recent openssl to get SAN support for when we compile wget
+RUN wget http://www.openssl.org/source/openssl-1.0.2j.tar.gz \
+    && tar xvf openssl-1.0.2j.tar.gz \
+    && cd openssl-1.0.2j \
+    && make clean \
+    && ./config shared --prefix=/usr --openssldir=/usr/local/openssl \
+    && make && make install
+
+# Get a new wget to avoid a bug with wildcard certs; but not so new that it
+# passes --utf8 to pod2man
+#
+# DO NOT remove the RedHat wget, as later installs may attempt to use yum to
+# fetch/update it. Rely on /usr/local/bin being before /usr/bin in the PATH.
+RUN wget http://ftp.gnu.org/gnu/wget/wget-1.19.1.tar.gz && \
+    tar xzvf wget-1.19.1.tar.gz && \
+    cd wget-1.19.1 && \
+    ./configure --with-ssl=openssl --with-libssl-prefix=/usr/lib64/openssl --prefix=/usr/local && \
+    make && make install
+
+# UPDATE THE CERTS. TRUST THE HAXX.
+RUN wget --no-check-certificate -O /etc/pki/tls/certs/ca-bundle.crt https://curl.haxx.se/ca/cacert.pem
+
+# install cmake
+RUN curl -Lk http://www.cmake.org/files/v2.8/cmake-2.8.10.tar.gz | tar xz && cd cmake-2.8.10 && ./configure && make && make install
+
+RUN wget --no-check-certificate https://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
+RUN yum -y install devtoolset-2-gcc devtoolset-2-binutils
+RUN yum -y install devtoolset-2-gcc-gfortran devtoolset-2-gcc-c++
+
+# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
+ARG JENKINS_GID=999
+ARG JENKINS_UID=999
+RUN groupadd -g $JENKINS_GID jenkins && \
+    useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
+    echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/docker/jenkins/Dockerfile.centos6.3
+++ b/docker/jenkins/Dockerfile.centos6.3
@@ -1,0 +1,39 @@
+FROM centos:6
+MAINTAINER Chad Barraford <chad@rstudio.com>
+
+# EPEL
+RUN     rpm -Uvh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+
+# RPMForge
+RUN     rpm -Uvh http://repoforge.mirror.constant.com/redhat/el6/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm
+
+# SSH
+EXPOSE 22
+RUN yum -y groupinstall "Development tools"
+RUN yum -y install rsyslog screen passwd java-1.7.0-openjdk sudo wget git python26 tar python-devel mercurial gcc glibc-devel xorg-x11-server-Xvfb firefox
+
+
+# There's a networking bug with some versions of git which sometimes causes
+# 'go get' to hang; force a git update.
+#
+# http://stackoverflow.com/questions/21820715/how-to-install-latest-version-of-git-on-centos-6-x
+# https://groups.google.com/forum/#!topic/golang-nuts/RKz9ASmJm3o
+RUN yum -y --disablerepo=base,updates --enablerepo=rpmforge-extras update git
+
+RUN yum install -y python-setuptools python-unittest2
+RUN yum install -y R curl libcurl-devel
+
+# install cmake
+RUN curl -Lk http://www.cmake.org/files/v2.8/cmake-2.8.10.tar.gz | tar xz
+RUN cd cmake-2.8.10 && ./configure && make && make install
+
+RUN wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
+RUN yum -y install devtoolset-2-gcc devtoolset-2-binutils
+RUN yum -y install devtoolset-2-gcc-gfortran devtoolset-2-gcc-c++
+
+# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
+ARG JENKINS_GID=999
+ARG JENKINS_UID=999
+RUN groupadd -g $JENKINS_GID jenkins && \
+    useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
+    echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/docker/jenkins/Dockerfile.ubuntu-12.04
+++ b/docker/jenkins/Dockerfile.ubuntu-12.04
@@ -1,0 +1,31 @@
+FROM ubuntu:precise
+
+ARG AWS_REGION=us-east-1
+
+# install needed packages. replace httpredir apt source with cloudfront
+RUN set -x \
+    && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA9EF27F \
+    && echo 'deb http://cran.rstudio.com/bin/linux/ubuntu precise/' >> /etc/apt/sources.list \
+    && echo 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main' >> /etc/apt/sources.list \
+    && apt-get update
+
+RUN apt-get update \
+  && apt-get install -y build-essential curl make gcc-4.8 g++-4.8 git python libssl-dev cmake r-base sudo wget
+
+WORKDIR /tmp
+RUN wget https://cmake.org/files/v2.8/cmake-2.8.11.2.tar.gz \
+  && tar xzf cmake-2.8.11.2.tar.gz \
+  && cd cmake-2.8.11.2 \
+  && ./configure \
+  && make \
+  && make install
+
+# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
+ARG JENKINS_GID=999
+ARG JENKINS_UID=999
+RUN groupadd -g $JENKINS_GID jenkins && \
+    useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
+    echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
Implements jenkins pipeline builds for shiny-server.

The pipelines can be found here:
https://buildmaster.rstudioservices.com/job/shiny/job/shiny-server-pipeline/ 
https://buildmaster.rstudioservices.com/job/shiny/job/shiny-server-pro-pipeline/
(there is temporarily no blue ocean link as we have disabled blue ocean due to a few show-stopping bugs).

Notes:
  * precise images are a fresh `Dockerfile` with deps needed, centos images are mainly a copy-paste from https://github.com/rstudio/jenkins-docker-images
  * Branch builds now persist build files to s3, builds on master persist to the standard location.
  * Any branches in GH that have `Jenkinsfile`s in them will automatically be added to the pipeline, and builds will execute on every push.

TODOs:
  * `doc`/`deploy` builds, if used. this process should likely be in its own `Jenkinsfile` so it can be set to only run on manual build
  * `test` builds. I've started moving some shiny test builds to jenkins pipelines, not sure the state of any left in the `shiny` directory.
  * set the `master` build number to match the legacy project's build number once it exists (a one-time action to make builds increment above their existing version)
