### PR TITLE
make-package-jenkins.sh: simplify node install, don't specify gcc/g++…

### DIFF
--- a/packaging/make-package-jenkins.sh
+++ b/packaging/make-package-jenkins.sh
@@ -4,11 +4,10 @@ set -e
 set -x
 
 # This is needed for CentOS5/6 Jenkins workers to bootstrap the gcc-4.8 toolchain.
-
 cd "$(dirname $0)"
 
 # This will set up two global variables: NODE_ARCHIVE_FILENAME and SAVE_NODE_BUILD.
-init_nodejs_vars() {
+init_vars() {
   local NODE_VER=`grep 'set(NODEJS_VERSION' ../external/node/CMakeLists.txt | sed 's/[^0-9.]//g'`
   # Expect node version to be x.y.z format
   if ! [[ "$NODE_VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -30,38 +29,28 @@ init_nodejs_vars() {
   # and use such a file from S3, or, we will build from source and create this
   # file (and expect Jenkins to upload it).
   NODE_ARCHIVE_FILENAME="node_${NODE_VER}_${OS}_${ARCH}.tar.gz"
-
-  # If 1, then after we build, we'll want to save the ext/node directory as a
-  # .tar.gz in the packaging/build directory. Jenkins will see to getting it
-  # uploaded to S3. The setup_cached_nodejs step will set this to 0 if it finds
-  # a cached build already present on S3.
-  SAVE_NODE_BUILD=1
 }
 
 # Attempt to retrieve a cached Node.js build from S3. If one is found, then we
-# will unpack it in ../ext and set SAVE_NODE_BUILD=0.
+# will unpack it in ../ext. Otherwise, we bail.
 setup_cached_nodejs () {
   # This is the URL where we'll expect to find a suitable cached build of Node.js, if one exists
   local NODE_ARCHIVE_URL="https://s3.amazonaws.com/rstudio-shiny-server-os-build/node/${NODE_ARCHIVE_FILENAME}"
-  mkdir -p ../ext
-  # The local path where we'll put the cached build, if we can find it
-  local NODE_ARCHIVE_DEST="../ext/${NODE_ARCHIVE_FILENAME}"
+  local NODE_ARCHIVE_DEST="/tmp/${NODE_ARCHIVE_FILENAME}"
 
-  wget -O "${NODE_ARCHIVE_DEST}" "${NODE_ARCHIVE_URL}" || rm -f "${NODE_ARCHIVE_DEST}"
   if [ -f "${NODE_ARCHIVE_DEST}" ]; then
-    SAVE_NODE_BUILD=0
-    echo "Using cached Node.js build from $NODE_ARCHIVE_URL" >&2
-    (cd ../ext && tar xzf "$NODE_ARCHIVE_FILENAME" && rm "$NODE_ARCHIVE_FILENAME")
+    # Pre-built Node exists locally already, unpack it
+    mkdir -p ../ext
+    tar xzf "${NODE_ARCHIVE_DEST}" -C ../ext
+  elif wget -S --spider "${NODE_ARCHIVE_URL}"; then
+    # Pre-built Node doesn't exist locally, but can be downloaded
+    wget -O "${NODE_ARCHIVE_DEST}" "${NODE_ARCHIVE_URL}"
+    mkdir -p ../ext
+    tar xzf "${NODE_ARCHIVE_DEST}" -C ../ext
   else
-    echo "No cached Node.js build found; will build from source (tried $NODE_ARCHIVE_URL)" >&2
-  fi
-}
-
-# If SAVE_NODE_BUILD=1, then tar-gzip ext/node and put it in packaging/build.
-archive_nodejs() {
-  if [ "$SAVE_NODE_BUILD" == "1" ]; then
-    echo "Saving node build as $NODE_ARCHIVE_FILENAME" >&2
-    (cd ../ext && tar czf "../packaging/build/$NODE_ARCHIVE_FILENAME" node)
+    # Node needs to be built
+    echo "Expected pre-built Node at this URL: ${NODE_ARCHIVE_URL}"
+    exit 1
   fi
 }
 
@@ -72,14 +61,12 @@ archive_nodejs() {
 # we must first blow it and any other files not in the repo away.
 git reset --hard && git clean -ffdx
 
-init_nodejs_vars
+init_vars
 setup_cached_nodejs
 
 if (which scl && scl -l | grep -q devtoolset-2);
 then
 	scl enable devtoolset-2 ./make-package.sh "$@"
 else
-	CC=gcc-4.8 CXX=g++-4.8 ./make-package.sh "$@"
+	CC=gcc CXX=g++ ./make-package.sh "$@"
 fi
-
-archive_nodejs


### PR DESCRIPTION
This PR does three things:

* Makes `make-package-jenkins.sh` work on Ubuntu 16.04. Switches from parameterizing CMake (via the `CC` and `CXX` env vars) to use `gcc` and `g++`, respectively, instead of the Ubuntu-12.04 dependent names `gcc-4.8` and `g++-4.8`. I figure if we have multiple gcc's laying around, it's something we need to fix in the Dockerfile.
* Removes the bash logic for building Node if a pre-built binary can't be found on S3. I think we probably don't ever want one build to influence the version of Node used by other builds. And we seem to manage the Node version pretty tightly, so building a new Node seems like something a human should do manually.
* If Node has already been downloaded to `/tmp`, skips downloading from S3. This is helpful when testing in Docker, and speeds up `make-package-jenkins.sh` for me locally by about 5-10 seconds.