### PR TITLE
Use HTTPS for Google Fonts on error page

### DIFF
--- a/templates/error.html
+++ b/templates/error.html
@@ -1,8 +1,8 @@
 <html>
 <head>
   <title>{{title}}</title>
-  <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro' rel='stylesheet' type='text/css'>
   <style type="text/css">
   body {
     font-family: 'Source Sans Pro', sans-serif;


### PR DESCRIPTION
tempates/directoryIndex.html has been using HTTPS for getting Google Fonts for several years, [see commit](https://github.com/rstudio/shiny-server/commit/f04e462ec5497c070b1301e280a56967af1436bd), however the error page does not. This has caused Firefox (56.0 on Mac OS X) to either not load the fonts or consider my connection to the server to be insecure. This should resolve the issue and the inconsistency. 