### PR TITLE
Fix #637 (SSP): Can't remove headers after they are sent

### DIFF
--- a/lib/proxy/http.js
+++ b/lib/proxy/http.js
@@ -247,24 +247,10 @@ function ShinyProxy(router, schedulerRegistry) {
       origEmit.apply(this, arguments);
     };
 
-    // Once we switched the connection between node and the R workers from TCP
-    // to Unix domain sockets, keepalive management from the node side seemed
-    // to stop working. The behavior we observed (using our manual loadtest.js
-    // script) was that node would request to keep the connection open, but not
-    // actually reuse the connection. This would lead the node process to hit
-    // the limit of open files (defaults to 1024 on Linux and only 256 on Mac).
-    //
-    // This fixes the problem by rewriting the Connection header in both
-    // directions while proxying; always close the connection to the target,
-    // while respecting the original connection header from the client.
-    proxy.on('proxyReq', function(proxyReq, req, res, options) {
-      req.keepalive = isKeepalive(req);
-      stripConnectionHeaders(proxyReq);
-      proxyReq.setHeader("connection", "close");
-    });
+    // proxy.on('proxyReq', function(proxyReq, req, res, options) {
+    // });
     proxy.on('proxyRes', function(proxyRes, req, res) {
       res.proxySuccess = proxyRes.statusCode && proxyRes.statusCode >= 200 && proxyRes.statusCode < 300;
-      res.setHeader("connection", req.keepalive ? 'keep-alive' : 'close');
       // Protect against clickjacking
       var frameOptions = appWorkerHandle.appSpec.settings.appDefaults.frameOptions;
       if (frameOptions) {

--- a/test/http-proxy.js
+++ b/test/http-proxy.js
@@ -1,0 +1,77 @@
+/*
+ * test/http-proxy.js
+ *
+ * Copyright (C) 2018 by RStudio, Inc.
+ *
+ * This program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+const assert = require("assert");
+const http = require("http");
+const httpProxy = require("http-proxy");
+
+describe("http-proxy", () => {  
+  it("doesn't use keepalive on proxied requests", done => {
+
+    // It's important that the http-proxy library we rely on, always make
+    // requests upstream with "Connection: close", both because Node.js may not
+    // handle keepalive correct (we're not sure) and also because versions of
+    // httpuv <= 1.3.6 had a bug where it wouldn't clear out headers correctly
+    // between requests on the same socket. This test sets up
+    //
+    //   client -> proxyServer -> upstreamServer
+    //
+    // and makes sure that client -> proxyServer requests have keepalive enabled
+    // and proxyServer -> upstreamServer requests do not. If this test ever
+    // fails, it means http-proxy no longer has the behavior we want and we'll
+    // have to write additional code to turn off keepalive. Commit eb73244289b17
+    // may be instructive.
+
+    const upstreamServer = http.createServer((req, res) => {
+      try {
+        assert.equal(req.headers.connection, "close");
+        done();
+      } catch(err) {
+        done(err);
+      } finally {
+        res.end();
+        cleanup();
+      }
+    });
+    upstreamServer.listen(9111);
+    
+    const proxy = httpProxy.createProxyServer({
+      target: "http://localhost:9111"
+    });
+
+    const proxyServer = http.createServer((req, res) => {
+      try {
+        assert.equal(req.headers.connection, "keep-alive");
+        proxy.web(req, res);
+      } catch (err) {
+        done(err);
+        res.end();
+        cleanup();
+      }
+    });
+    proxyServer.listen(9112);
+
+    const keepAliveAgent = new http.Agent({ keepAlive: true });
+
+    function cleanup() {
+      proxyServer.close();
+      upstreamServer.close();
+      keepAliveAgent.destroy();
+    }
+
+    http.get({
+      host: "localhost",
+      port: 9112,
+      agent: keepAliveAgent
+    });
+  });
+});


### PR DESCRIPTION
We used to go through some trouble to have HTTP keepalive between
browsers and Shiny Server, but not keepalive (Connection: close)
between Shiny Server and Shiny (R process). Previously we cared
about this because when we used unix domain sockets to communicate
between Shiny Server and Shiny, connection pooling didn't work
right (at least not in those days, Node v0.8 probably). Now we
don't use unix domain sockets, but we found out during Winston's
httpuv background-thread work that with keepalive enabled, we
weren't properly resetting header information between requests.
This isn't so bad in local cases, but for the SS->Shiny connection
this could be very bad since we could be proxying requests on
behalf of different users over the same connections.

It turns out that we didn't need to do this work after all; it is
the default behavior of node-http-proxy anyway:
https://github.com/nodejitsu/node-http-proxy/blob/812757541db6a6eb9021dc459830d7c0a9b4429d/lib/http-proxy/common.js#L66-L75

I've confirmed using wireshark that indeed the TCP connections
between SS and Shiny are closed every time, but kept alive
between browser and SS.

Note that neither I (nor, to my knowledge, Alan or Fereshteh)
were ever able to repro the issue, which was supposed to cause
this crash when a POST request was proxied.