### PR TITLE
Support gzip/deflate compression for HTTP responses

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+shiny-server 1.5.7
+--------------------------------------------------------------------------------
+
+* Support gzip/deflate compression for HTTP responses. You can disable this if
+  necessary with the directive "http_allow_compression no;" at the top level
+  of shiny-server.conf.
+
 shiny-server 1.5.6
 --------------------------------------------------------------------------------
 

--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -155,6 +155,13 @@ http_keepalive_timeout {
   maxcount 1;
 }
 
+http_allow_compression {
+  desc "Whether gzip/deflate compression is supported for HTTP responses. If this directive is not included, the default behavior is to support gzip/deflate compression.";
+  param Boolean [enabled] "Whether or not this is enabled. Default is true." true;
+  at $;
+  maxcount 1;
+}
+
 sockjs_heartbeat_delay {
   desc "How often the SockJS server should send heartbeat packets to the server. These are used to prevent proxies and load balancers from closing active SockJS connections. Defaults to 25 seconds.";
   param Float delay "The number of seconds to wait between heartbeat packets.";

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,6 +18,7 @@ var fs = require('fs');
 var path = require('path');
 var url = require('url');
 var util = require('util');
+var compression = require('compression');
 var client_sessions = require('client-sessions');
 var express = require('express');
 var morgan = require('morgan');
@@ -139,6 +140,9 @@ var shinyProxy = new proxy_http.ShinyProxy(
   schedulerRegistry
 );
 
+var compressionMiddleware = compression();
+let useCompression = true;
+
 var clientSessionMiddleware = client_sessions({
   secret: crypto.randomBytes(16).toString('hex')
 });
@@ -151,6 +155,12 @@ var sockjsHandler = function(req, res){
 }
 
 var app = express();
+app.use(function(req, res, next) {
+  if (useCompression)
+    compressionMiddleware(req, res, next);
+  else
+    next();
+});
 app.use(clientSessionMiddleware);
 app.use(function(req, res, next) {
   if (!sockjsHandler(req, res))
@@ -241,6 +251,8 @@ var loadConfig_p = qutil.serialized(function() {
     sockjsHandler = sockjsServer.middleware();
 
     socketTimeout = configRouter.httpKeepaliveTimeout;
+
+    useCompression = configRouter.httpAllowCompression;
 
     return createLogger_p(configRouter.accessLogSpec)
     .then(function(logfunc) {

--- a/lib/router/config-router.js
+++ b/lib/router/config-router.js
@@ -108,6 +108,11 @@ function ConfigRouter(conf, schedulerRegistry) {
   this.$allowAppOverride = conf.getValues('allow_app_override').enabled;
   this.$templateDir = conf.getValues('template_dir').dir;
 
+  this.httpAllowCompression = true;
+  if (conf.getOne('http_allow_compression')) {
+    this.httpAllowCompression = conf.getValues('http_allow_compression').enabled;
+  }
+
   this.httpKeepaliveTimeout = 45 * 1000;
   if (conf.getOne('http_keepalive_timeout')) {
     this.httpKeepaliveTimeout = conf.getValues('http_keepalive_timeout').timeout * 1000;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -199,6 +199,16 @@
         }
       }
     },
+    "compressible": {
+      "version": "2.0.13",
+      "from": "compressible@>=2.0.13 <2.1.0",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz"
+    },
+    "compression": {
+      "version": "1.7.2",
+      "from": "compression@latest",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz"
+    },
     "concat-map": {
       "version": "0.0.1",
       "from": "concat-map@0.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "bash": "0.0.1",
     "client-sessions": "^0.8.0",
+    "compression": "^1.7.2",
     "express": "^4.16.2",
     "faye-websocket": "^0.11.0",
     "graceful-fs": "4.1.x",


### PR DESCRIPTION
Testing notes: Use Chrome network inspector to see if HTTP responses include `Content-Encoding: gzip` headers.