### PR TITLE
Move server (re)starting logic to posttrans, for correct upgrades

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ set(DEBIAN_PRERM prerm.in)
 set(DEBIAN_POSTRM postrm.in)
 
 # rpm scripts
+set(RPM_POSTTRANS posttrans.sh.in)
 set(RPM_POSTINST postinst.sh.in)
 set(RPM_POSTRM postrm.sh.in)
 
@@ -143,6 +144,9 @@ set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_BINARY_DIR}/packaging/de
 # dynamically configured rpm scripts (only works with cmake 2.8.1 or higher). 
 # alternatively you can get CPackRPM.cmake from the cmake tip and copy it into
 # your local cmake modules directory -- this is what we currently do
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/packaging/rpm-script/${RPM_POSTTRANS}
+               ${CMAKE_CURRENT_BINARY_DIR}/packaging/rpm-script/posttrans.sh)
+file(READ ${CMAKE_CURRENT_BINARY_DIR}/packaging/rpm-script/posttrans.sh RPM_POSTTRANS_SCRIPT)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/packaging/rpm-script/${RPM_POSTINST}
                ${CMAKE_CURRENT_BINARY_DIR}/packaging/rpm-script/postinst.sh)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/packaging/rpm-script/${RPM_POSTRM}

--- a/packaging/rpm-script/postinst.sh.in
+++ b/packaging/rpm-script/postinst.sh.in
@@ -45,43 +45,7 @@ chown shiny:shiny /var/log/shiny-server
 
 mkdir -p /var/lib/shiny-server
 
-RH_VER=""
-if test -e /etc/redhat-release
-then
-  RH_VER=`sed -nr "s/.*release\\ ([0-9]).*/\\1/p" /etc/redhat-release`
-fi
 
-# add upstart profile, or init.d/systemd script and start the server
-if test -d /etc/init/
-then
-   # remove any previously existing init.d based scheme
-   service shiny-server stop 2>/dev/null
-   rm -f /etc/init.d/shiny-server
-
-   cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/upstart/shiny-server.conf /etc/init/
-   initctl reload-configuration
-   initctl stop shiny-server 2>/dev/null
-   sleep 1
-   initctl start shiny-server
-elif [ "$RH_VER" == "7" ]
-then
-   cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/systemd/shiny-server.service /etc/systemd/system/
-   systemctl enable shiny-server
-   systemctl restart shiny-server
-else
-   if test -e /etc/SuSE-release
-   then
-      cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/init.d/suse/shiny-server /etc/init.d/
-   else
-      cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/init.d/redhat/shiny-server /etc/init.d/
-   fi
-
-   chmod +x /etc/init.d/shiny-server
-   chkconfig --add shiny-server
-   service shiny-server stop 2>/dev/null
-   sleep 1
-   service shiny-server start
-fi
-
-# clear error termination state
-set -e
+# Do not remove!
+%posttrans
+${RPM_POSTTRANS_SCRIPT}

--- a/packaging/rpm-script/posttrans.sh.in
+++ b/packaging/rpm-script/posttrans.sh.in
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# errors shouldn't cause script to exit
+set +e
+
+RH_VER=""
+if test -e /etc/redhat-release
+then
+  RH_VER=`sed -nr "s/.*release\\ ([0-9]).*/\\1/p" /etc/redhat-release`
+fi
+
+# add upstart profile, or init.d/systemd script and start the server
+if test -d /etc/init/
+then
+   # remove any previously existing init.d based scheme
+   service shiny-server stop 2>/dev/null
+   rm -f /etc/init.d/shiny-server
+
+   cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/upstart/shiny-server.conf /etc/init/
+   initctl reload-configuration
+   initctl stop shiny-server 2>/dev/null
+   sleep 1
+   initctl start shiny-server
+elif [ "$RH_VER" == "7" ]
+then
+   cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/systemd/shiny-server.service /etc/systemd/system/
+   systemctl enable shiny-server
+   systemctl restart shiny-server
+else
+   if test -e /etc/SuSE-release
+   then
+      cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/init.d/suse/shiny-server /etc/init.d/
+   else
+      cp ${CMAKE_INSTALL_PREFIX}/shiny-server/config/init.d/redhat/shiny-server /etc/init.d/
+   fi
+
+   chmod +x /etc/init.d/shiny-server
+   chkconfig --add shiny-server
+   service shiny-server stop 2>/dev/null
+   sleep 1
+   service shiny-server start
+fi
+
+# clear error termination state
+set -e


### PR DESCRIPTION
During upgrades, server restarts were happening during a phase of the rpm
lifecycle where files from BOTH old and new versions of the package were
on disk. In some cases we can get the wrong behavior (e.g. npm packages
existing in a nested location in the old version, whereas it moves to the
top level in the new version; we would (and did) pick up the old version
until the server is restarted).

The correct place to restart is during posttrans. CPackRPM doesn't have
a posttrans feature, but we can fake it by tacking %posttrans to the end
of any other script.