### PR TITLE
Don't color logs if not at a terminal

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ shiny-server 1.5.7
   necessary with the directive "http_allow_compression no;" at the top level
   of shiny-server.conf.
 
+* Don't color log output if stdout is not a terminal.
+
 shiny-server 1.5.6
 --------------------------------------------------------------------------------
 

--- a/lib/core/log.js
+++ b/lib/core/log.js
@@ -10,9 +10,18 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-var log4js = require('log4js');
+const log4js = require("log4js");
+const tty = require("tty");
+
+// Only use colored output if stdout is a tty
+const appender = tty.isatty(process.stdout.fd) ? "colored" : "basic";
+log4js.configure({
+  appenders: { "out": { type: "stdout", layout: { type: appender } } },
+  categories: { default: { appenders: ["out"], level: "info" } }
+});
 
 global.logger = log4js.getLogger('shiny-server');
+
 // Backward compatibility shim for log4js
 logger.constructor.prototype.setLevel = function(level) {
   this.level = level;


### PR DESCRIPTION
Log messages have always contained color codes, which make
log files look weird in utilities like less or editors like
vim.

This commit causes coloring only to be used if stdout is
a tty.