### PR TITLE
Use prebuilt binaries of Node.js

### DIFF
--- a/external/node/CMakeLists.txt
+++ b/external/node/CMakeLists.txt
@@ -2,8 +2,8 @@ project(node)
 
 set(NODEJS_VERSION 8.10.0)
 # See e.g. http://nodejs.org/dist/v0.10.21/SHASUMS.txt to find the appropriate
-# hash value for the node-v0.10.21.tar.gz file.
-set(NODEJS_SHA256 57ddd302260f77fa6dfe774f97b196828ec7c08aafbbd8def5e527a388d18f2d)
+# hash value for the node-v0.10.21-linux-x64.tar.xz file.
+set(NODEJS_SHA256 92220638d661a43bd0fee2bf478cb283ead6524f231aabccf14c549ebc2bc338)
 
 include(ExternalProject)
 
@@ -33,15 +33,13 @@ if (NOT NODEVER STREQUAL "v${NODEJS_VERSION}")
   # show "shiny-server" for our process.
   ExternalProject_Add(
     node
-    URL http://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}.tar.gz
+    URL http://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.xz
     URL_HASH SHA256=${NODEJS_SHA256}
     DOWNLOAD_DIR download
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/node-v${NODEJS_VERSION}
-    BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/node-v${NODEJS_VERSION}/configure
-                      "--prefix=${NODE_PREFIX}"
-    BUILD_COMMAND make -j4 PYTHON=${PYTHON}
-    INSTALL_COMMAND make install &&
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/node-v${NODEJS_VERSION}-linux-x64
+    CONFIGURE_COMMAND echo pass
+    BUILD_COMMAND echo pass
+    INSTALL_COMMAND cp -R "${CMAKE_CURRENT_SOURCE_DIR}/node-v${NODEJS_VERSION}-linux-x64" "${NODE_PREFIX}" &&
                     cp "${NODE_PREFIX}/bin/node" "${NODE_PREFIX}/bin/shiny-server" &&
                     rm "${NODE_PREFIX}/bin/npm" &&
                     cd "${NODE_PREFIX}/lib/node_modules/npm" &&

--- a/packaging/make-package-jenkins.sh
+++ b/packaging/make-package-jenkins.sh
@@ -85,8 +85,12 @@ setup_cached_nodejs () {
 # we must first blow it and any other files not in the repo away.
 git reset --hard && git clean -ffdx
 
-init_vars
-setup_cached_nodejs
+## jcheng 2018-03-15: Don't download our own nodejs builds, we are having
+## trouble getting them to build with a GLIBCXX version that's 3.4.19 or
+## less. Instead, just use the binaries from nodejs.org, which we'll do
+## as part of the cmake configure.
+# init_vars
+# setup_cached_nodejs
 
 if (which scl && scl -l | grep -q devtoolset-2);
 then

--- a/packaging/make-package-jenkins.sh
+++ b/packaging/make-package-jenkins.sh
@@ -6,91 +6,12 @@ set -x
 # This is needed for CentOS5/6 Jenkins workers to bootstrap the gcc-4.8 toolchain.
 cd "$(dirname $0)"
 
-# Given an OS identifier for this build, return the corresponding OS for the Node build.
-determine_node_os() {
-  local os="$1"
-  if [[ "$os" =~ ^centos* ]]; then
-    echo "centos-6"
-  elif [[ "$os" =~ ^ubuntu* ]]; then
-    echo "ubuntu-14.04"
-  else
-    echo "Unknown Node os: ${os}"
-  fi
-}
-
-# This will set up two global variables: NODE_ARCHIVE_FILENAME, NODE_ARCHIVE_CHECKSUM
-init_vars() {
-  local NODE_VER=`grep 'set(NODEJS_VERSION' ../external/node/CMakeLists.txt | sed 's/[^0-9.]//g'`
-  local NODE_OS
-  # Expect node version to be x.y.z format
-  if ! [[ "$NODE_VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Couldn't parse node version" >&2
-    exit 1
-  fi
-
-  if [ "$OS" == "" ]; then
-    echo "Missing 'OS' Jenkins environment variable" >&2
-    exit 1
-  fi
-
-  if [ "$ARCH" == "" ]; then
-    echo "Missing 'ARCH' Jenkins environment variable" >&2
-    exit 1
-  fi
-
-  NODE_OS="$(determine_node_os ${OS})"
-
-  # The filename of a suitable cached build of Node.js. We will either download
-  # and use such a file from S3, or, we will build from source and create this
-  # file (and expect Jenkins to upload it).
-  NODE_ARCHIVE_FILENAME="node_${NODE_VER}_${NODE_OS}_${ARCH}.tar.gz"
-
-  # Checksum corresponding to the Node build
-  NODE_ARCHIVE_CHECKSUM="node_${NODE_VER}_${NODE_OS}_${ARCH}_sha256sum.txt.asc"
-}
-
-# Attempt to retrieve a cached Node.js build from S3. If one is found, then we
-# will unpack it in ../ext. Otherwise, we bail.
-setup_cached_nodejs () {
-  # This is the URL where we'll expect to find a suitable cached build of Node.js, if one exists
-  local NODE_ARCHIVE_URL="https://s3.amazonaws.com/rstudio-shiny-server-os-build/node-builds/${NODE_ARCHIVE_FILENAME}"
-  local NODE_CHECKSUM_URL="https://s3.amazonaws.com/rstudio-shiny-server-os-build/node-builds/${NODE_ARCHIVE_CHECKSUM}"
-  local NODE_ARCHIVE_DEST="/tmp/${NODE_ARCHIVE_FILENAME}"
-  local NODE_CHECKSUM_DEST="/tmp/${NODE_ARCHIVE_CHECKSUM}"
-
-  if [ -f "${NODE_ARCHIVE_DEST}" ]; then
-    # Pre-built Node exists locally already, unpack it
-    mkdir -p ../ext
-    tar xzf "${NODE_ARCHIVE_DEST}" -C ../ext
-  elif wget -S --spider "${NODE_ARCHIVE_URL}"; then
-    # Pre-built Node doesn't exist locally, but can be downloaded
-    wget -O "${NODE_ARCHIVE_DEST}" "${NODE_ARCHIVE_URL}"
-    wget -O "${NODE_CHECKSUM_DEST}" "${NODE_CHECKSUM_URL}"
-    cd /tmp
-    sha256sum -c ${NODE_ARCHIVE_CHECKSUM}
-    cd -
-    mkdir -p ../ext
-    tar xzf "${NODE_ARCHIVE_DEST}" -C ../ext
-  else
-    # Node needs to be built
-    echo "Expected pre-built Node at this URL: ${NODE_ARCHIVE_URL}"
-    exit 1
-  fi
-}
-
 # Repo checkout directories are re-used by Jenkins workers, and so a
 # $PROJECT_DIR/packaging/build/CMakeCache.txt might be hanging around from a
 # previous build. This cache file is platform-specific, and the build that
 # generated it may have been on a different platform. In order to build reliably
 # we must first blow it and any other files not in the repo away.
 git reset --hard && git clean -ffdx
-
-## jcheng 2018-03-15: Don't download our own nodejs builds, we are having
-## trouble getting them to build with a GLIBCXX version that's 3.4.19 or
-## less. Instead, just use the binaries from nodejs.org, which we'll do
-## as part of the cmake configure.
-# init_vars
-# setup_cached_nodejs
 
 if (which scl && scl -l | grep -q devtoolset-2);
 then


### PR DESCRIPTION
We were having trouble building Node.js with a modern enough gcc that
it would compile, but binding to an old enough libstdc++ that we
would just work on older platforms.