### PR TITLE
Update relative paths of JS lib imports

### DIFF
--- a/lib/config/app-config.js
+++ b/lib/config/app-config.js
@@ -10,8 +10,8 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-var config = require('../config/config');
-var schema = require('../config/schema');
+var config = require('./config');
+var schema = require('./schema');
 var fsutil = require('../core/fsutil');
 var map = require('../core/map');
 var paths = require('../core/paths');


### PR DESCRIPTION
Updated the relative paths to point to the current `config` directory. `../config/` seemed unnecessary.