### PR TITLE
Update install-node.sh: NODE_FILENAME

### DIFF
--- a/external/node/install-node.sh
+++ b/external/node/install-node.sh
@@ -6,6 +6,7 @@ set -e
 # See e.g. https://nodejs.org/dist/v8.10.0/SHASUMS256.txt for checksum.
 NODE_VERSION=8.10.0
 NODE_SHA256=92220638d661a43bd0fee2bf478cb283ead6524f231aabccf14c549ebc2bc338
+NODE_DIST=linux-x64 # Choose the correct distribution, e.g armv7l | linux | ...
 
 cd $(dirname $0)
 cd ../..
@@ -31,7 +32,7 @@ verify_checksum () {
 }
 
 download_node () {
-  local NODE_FILENAME="node-v${NODE_VERSION}-linux-x64.tar.xz"
+  local NODE_FILENAME="node-v${NODE_VERSION}-${NODE_DIST}.tar.xz"
   local NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_FILENAME}"
   local NODE_ARCHIVE_DEST="/tmp/${NODE_FILENAME}"
   echo "Downloading Node v${NODE_VERSION} from ${NODE_URL}"


### PR DESCRIPTION
When I tried to install the node through this script on my raspberry, independent of the chosen NODE_SHA256 the downloaded node was the same because of the NODE_FILENAME definition, that was hold on linux-x64. With this change, it´s more explicit the need for select the right distribution - This change has revelance once the number of unsucess on installing shiny server on raspberry is high, in general because of this issue.