### PR TITLE
Remove dependency on node-unixgroups (fixes #354)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -9,7 +9,6 @@ Shiny Server includes other open source software components. The following is a 
  - q
  - bash
  - log4js-node
- - unixgroups
  - moment
  - stable
  - optimist
@@ -444,31 +443,6 @@ Original License:
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-```
-
-### unixgroups
-
-```
-Copyright 2012 Joe Rozner
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 ### moment

--- a/lib/worker/run-as.js
+++ b/lib/worker/run-as.js
@@ -17,7 +17,6 @@
 //
 // Usage: run-as.js <user> <command> <args>
 
-var unixgroups = require('unixgroups');
 var child_process = require('child_process');
 var _ = require('underscore');
 var posix = require('../../build/Release/posix');
@@ -26,7 +25,9 @@ var map = require('../core/map');
 
 // Drop permissions first
 var user = process.argv[2];
-unixgroups.initgroups(user, true); // also calls setgid
+var pwd = posix.getpwnam(user);
+process.initgroups(user, pwd.gid);
+process.setgid(pwd.gid);
 process.setuid(user);
 
 
@@ -35,7 +36,6 @@ var args = _.rest(process.argv, 4);
 
 // Change a few env variables to match user's identity
 var env = map.create();
-var pwd = posix.getpwnam(user);
 env.USER = user;
 env.LOGNAME = user;
 env.HOME = pwd.home;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1166,11 +1166,6 @@
       "from": "underscore@1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
-    "unixgroups": {
-      "version": "0.2.0",
-      "from": "https://github.com/rstudio/node-unixgroups/tarball/e6dfefe",
-      "resolved": "https://github.com/rstudio/node-unixgroups/tarball/e6dfefe"
-    },
     "unpipe": {
       "version": "1.0.0",
       "from": "unpipe@>=1.0.0 <1.1.0",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "sockjs": "^0.3.19",
     "split": "^1.0.1",
     "stable": "^0.1.6",
-    "underscore": "1.8.3",
-    "unixgroups": "https://github.com/rstudio/node-unixgroups/tarball/e6dfefe"
+    "underscore": "1.8.3"
   },
   "license": "AGPL-3.0",
   "engines": {

--- a/tools/check-licenses.js
+++ b/tools/check-licenses.js
@@ -19,7 +19,6 @@ var KNOWN_LICENSES = {
   "ms@0.6.2":             "MIT",
   "ms@0.7.1":             "MIT",
   "samsam@1.1.2":         "BSD-3-Clause",
-  "unixgroups@0.2.0":     "MIT",
 };
 
 function readJSON(file) {


### PR DESCRIPTION
Since  Node.js version 0.9.4 this can be done with process.initgroups as well.