### PR TITLE
X-Powered-By now reports Shiny Server

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@ shiny-server 1.5.8
 
 * Added support for listening on IPv6 addresses.
 
-* X-Powered-By response header now reports "Shiny Server" instead of "Express"
+* X-Powered-By response header now reports "Shiny Server" instead of "Express".
 
 shiny-server 1.5.7
 --------------------------------------------------------------------------------

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ shiny-server 1.5.8
 
 * Added support for listening on IPv6 addresses.
 
+* X-Powered-By response header now reports "Shiny Server" instead of "Express"
+
 shiny-server 1.5.7
 --------------------------------------------------------------------------------
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -59,7 +59,8 @@ var SquashRunAsRouter = require('./router/squash-run-as-router.js');
   }
 })();
 
-var shinyVersionString = 'Shiny Server v' + SHINY_SERVER_VERSION;
+var serverName = 'Shiny Server';
+var shinyVersionString = `${serverName} v` + SHINY_SERVER_VERSION;
 var nodeVersionString = 'Node.js ' + process.version;
 var versionString = shinyVersionString + ' (' + nodeVersionString + ')';
 
@@ -155,6 +156,11 @@ var sockjsHandler = function(req, res){
 }
 
 var app = express();
+app.disable('x-powered-by');
+app.use((req, res, next) => {
+  res.setHeader('X-Powered-By', serverName);
+  next();
+})
 app.use(function(req, res, next) {
   if (useCompression)
     compressionMiddleware(req, res, next);

--- a/lib/main.js
+++ b/lib/main.js
@@ -160,7 +160,7 @@ app.disable('x-powered-by');
 app.use((req, res, next) => {
   res.setHeader('X-Powered-By', serverName);
   next();
-})
+});
 app.use(function(req, res, next) {
   if (useCompression)
     compressionMiddleware(req, res, next);


### PR DESCRIPTION
The `X-Powered-By` header in responses currently reports `Express`. This change replaces `X-Powered-By` with `Shiny Server`

Example:

```
alandipert@frito~/g/r/shiny-server➜ curl -I http://localhost:3838/001-hello/
HTTP/1.1 200 OK
X-Powered-By: Shiny Server
x-ua-compatible: IE=edge,chrome=1
content-type: text/html; charset=UTF-8
content-length: 2233
connection: close
Vary: Accept-Encoding
Date: Mon, 14 May 2018 19:46:34 GMT
```