### PR TITLE
Actively reject listening on IPv6 addresses with zone IDs

### DIFF
--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -36,7 +36,7 @@ listen {
   desc "Directs the enclosing server scope to listen on the specified port/IP address combination.";
   param Integer port "Port to listen on";
   # Optional parameter
-  param String [host] "IP address to listen on (`*` or `::` for all, or `0.0.0.0` for all IPv4); hostnames are not currently allowed, please use raw IPv4 or IPv6 address only" *;
+  param String [host] "IP address to listen on (`*` or `::` for all, or `0.0.0.0` for all IPv4); hostnames are not allowed, please use raw IPv4 or IPv6 address only. IPv6 zone IDs are not supported." *;
   at server;
   maxcount 1;
 }

--- a/lib/core/iputil.js
+++ b/lib/core/iputil.js
@@ -35,6 +35,12 @@ function isValid(addr) {
   return new Address4(addr).isValid() || new Address6(addr).isValid();
 }
 
+exports.hasZone = hasZone;
+function hasZone(addr) {
+  const addr6 = new Address6(addr);
+  return addr6.isValid() && addr6.zone;
+}
+
 exports.normalize = normalize;
 function normalize(addr) {
   const addr4 = new Address4(addr);
@@ -42,7 +48,7 @@ function normalize(addr) {
     return addr4.correctForm();
   const addr6 = new Address6(addr);
   if (addr6.isValid())
-    return addr6.correctForm();
+    return addr6.correctForm() + addr6.zone;
   throw new Error(`Invalid IP address: "addr"`);
 }
 
@@ -60,7 +66,7 @@ function equal(addr1, addr2) {
   // normalize and compare
   const a1 = new Address4(addr1).isValid() ? Address6.fromAddress4(addr1) : new Address6(addr1);
   const a2 = new Address4(addr2).isValid() ? Address6.fromAddress4(addr2) : new Address6(addr2);
-  return a1.canonicalForm() === a2.canonicalForm();
+  return (a1.canonicalForm() + a1.zone) === (a2.canonicalForm() + a2.zone);
 }
 
 /**

--- a/lib/router/config-router.js
+++ b/lib/router/config-router.js
@@ -212,6 +212,11 @@ function createServers(conf) {
           new Error('Invalid IP address "' + host + '"'));
     }
 
+    if (iputil.hasZone(host)) {
+      throwForNode(listenNode,
+          new Error(`Invalid IP address "${host}"--zone IDs are not currently supported`))
+    }
+
     var serverNames = serverNode.getValues('server_name').names;
 
     // Read all locations. Use post-order traversal so that nested locs

--- a/test/iputil.js
+++ b/test/iputil.js
@@ -26,7 +26,8 @@ describe("iputil", () => {
       "::0001",
       "fe80::1b38:f53:e5f2:f9e2",
       "fe80:1b38:f53:e5f2::f9e2",
-      "0000:0000:0000:0000:0000:0000:0000:0000"
+      "fe80::1b38:f53:e5f2:f9e2%ens33",
+      "0000:0000:0000:0000:0000:0000:0000:0000",
     ];
     yes.forEach(x => assert(iputil.isValid(x)));
 
@@ -57,12 +58,20 @@ describe("iputil", () => {
     assert(iputil.isWildcard("0:0:0::0000"));
   });
 
+  it("normalizes", () => {
+    assert.equal(iputil.normalize("::1"), "::1");
+    assert.equal(iputil.normalize("0:0:0::1"), "::1");
+    assert.equal(iputil.normalize("fe80::1b38:f53:e5f2:f9e2%ens33"), "fe80::1b38:f53:e5f2:f9e2%ens33");
+  });
+
   it("implicitly normalizes when testing for equality", () => {
     assert(iputil.equal("::ffff:10.11.12.13", "10.11.12.13"));
     assert(iputil.equal("127.0.0.1", "127.0.0.1"));
 
     assert(!iputil.equal("10.11.12.13", "10.11.12.14"));
     assert(!iputil.equal("127.0.0.1", "::1"));
+
+    assert(!iputil.equal("fe80::1b38:f53:e5f2:f9e2%ens33", "fe80::1b38:f53:e5f2:f9e2"));
   });
 
   it("wraps in [] appropriately", () => {


### PR DESCRIPTION
Node.js doesn't support url.parse on URLs whose hosts are
IPv6 addresses with zone IDs.

Contrast these two results:

```
> require('url').parse("http://[::1]:3838").hostname
'::1'
> 
> require('url').parse("http://[::1%test]:3838").hostname
''
```

Until this is fixed we'll simply reject listening on these
addresses. You can still listen on them using `::`.

### Testing notes

If you try to use a listen directive like `listen 3838 ::1%test;` we should throw a config error saying that zone IDs are not supported.