### PR TITLE
Exit code should be nonzero in case of error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,11 @@ shiny-server 1.5.8
 * `log_file_mode` no longer respects the process umask, and the default has been
   changed from `0660` to `0640`.
 
+* Exit code of shiny-server process was always 0, regardless of the reason the
+  process exited. Now a non-zero exit code is used if the process was terminated
+  by a signal, or an unhandled error crashed the process, or loading of the
+  shiny-server.conf config file failed during startup.
+
 shiny-server 1.5.7
 --------------------------------------------------------------------------------
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -272,10 +272,17 @@ var loadConfig_p = qutil.serialized(function() {
     } else {
       logger.error('Error loading config: ' + err.message);
     }
+    throw err;
   });
 });
 
-loadConfig_p().done();
+loadConfig_p()
+.fail(err => {
+  // If we fail to load the config during startup, exit with a
+  // failing error code.
+  process.exit(1);
+})
+.eat();
 
 function createLogger_p(logSpec) {
   if (!logSpec || !logSpec.path) {
@@ -313,7 +320,7 @@ function createLogger_p(logSpec) {
 process.on('SIGHUP', function() {
   logger.info('SIGHUP received, reloading configuration');
   render.flushCache();
-  loadConfig_p().done();
+  loadConfig_p().eat();
 });
 
 // On SIGUSR1, write worker registry contents to log
@@ -323,7 +330,10 @@ process.on('SIGUSR1', function() {
 
 // Clean up worker processes on shutdown
 
-var needsCleanup = true;
+// Save exit code as global, cause exiting involves lots of callbacks. 
+let exitCode = 0;
+// Ensure cleanup only happens once.
+let needsCleanup = true;
 function gracefulShutdown() {
   // Sometimes the signal gets sent twice. No idea why.
   if (!needsCleanup)
@@ -340,10 +350,16 @@ function gracefulShutdown() {
   logger.info('Shutting down worker processes (with notification)');
   schedulerRegistry.shutdown();
   needsCleanup = false;
-  setTimeout(process.exit, 500);
+  setTimeout(() => {
+    process.exit(exitCode);
+  }, 500);
 }
 
-function lastDitchShutdown() {
+function lastDitchShutdown(code) {
+  if (exitCode === 0 && code !== 0) {
+    exitCode = code;
+  }
+
   if (!needsCleanup)
     return;
   // More-violent shutdown (e.g. uncaught exception), no chance to notify
@@ -353,10 +369,17 @@ function lastDitchShutdown() {
   schedulerRegistry.shutdown();
 }
 
-process.on('SIGINT', gracefulShutdown);
-process.on('SIGTERM', gracefulShutdown);
-process.on('SIGABRT', gracefulShutdown);
-process.on('uncaughtException2', gracefulShutdown);
+function shutdownWithExitCode(code) {
+  return () => {
+    exitCode = code;
+    gracefulShutdown();
+  };
+}
+
+process.on('SIGINT', shutdownWithExitCode(128 + 2));
+process.on('SIGTERM', shutdownWithExitCode(128 + 15));
+process.on('SIGABRT', shutdownWithExitCode(128 + 6));
+process.on('uncaughtException2', shutdownWithExitCode(1));
 process.on('uncaughtException', function(err) {
   logger.error('Uncaught exception: ' + err);
   logger.error(err.stack);


### PR DESCRIPTION
## Test notes

Run shiny-server from the command line. Whenever it exits, use `echo $?` immediately to see the exit code. With previous versions, that should always be `0`. With this fix, it should be non-zero for error cases.

Scenarios to try:

1. Hit Ctrl-C to stop the server (equivalent of sending SIGINT)
2. From another terminal, `killall -SIGTERM shiny-server` (might need sudo)
3. Try to start shiny-server with invalid directives in the shiny-server.conf config file
4. `shiny-server --version` (this one _should_ return `0`)

I'm not sure, but I think maybe this will help systemd to more reliably restart on failure (only)? I don't actually know the behavior today--I think it does restart shiny-server automatically, even though the exit code has always been 0.