### PR TITLE
Use newer build of shiny-server-client

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1293,8 +1293,8 @@
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "shiny-server-client": {
-      "version": "https://github.com/rstudio/shiny-server-client/archive/a966800.tar.gz",
-      "integrity": "sha512-fM4k4MHFQHcMvgC6AYVxUiXxhSFCmDTRX9EhFY0CFlKuKS2SN8z0+1QJKCAcZO6clcAoTND7oHsjY6WrcHrSqg==",
+      "version": "https://github.com/rstudio/shiny-server-client/archive/fb1aef1.tar.gz",
+      "integrity": "sha512-GMU9cYcXuO8fCaD2whPD5ZlitPDmrvBmWSQJpMa5mmiX1CxupoK4mcgw9+LceCtaDBXAadHdEcDv1naFjs5+wg==",
       "requires": {
         "inherits": "2.0.3",
         "pinkyswear": "2.2.3"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "qs": "^6.5.1",
     "rewire": "^3.0.2",
     "send": "^0.16.2",
-    "shiny-server-client": "https://github.com/rstudio/shiny-server-client/archive/a966800.tar.gz",
+    "shiny-server-client": "https://github.com/rstudio/shiny-server-client/archive/fb1aef1.tar.gz",
     "should": "^13.2.1",
     "sinon": "^4.3.0",
     "sockjs": "^0.3.19",


### PR DESCRIPTION
There were some PRs that had not been merged, plus the one that prevents MS Edge from using xhr-streaming.