### PR TITLE
Added note that setting app_idle_timeout to 0 will disable. 

### DIFF
--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -142,7 +142,7 @@ app_init_timeout {
 }
 
 app_idle_timeout {
-  desc "Defines the amount of time an R process will persist with no connections before being terminated.";
+  desc "Defines the amount of time an R process will persist with no connections before being terminated. Defaults to 5 seconds. Set to 0 to disable.";
   param Integer timeout "The number of seconds to keep an empty R process alive before killing it.";
   at $ server location application;
   maxcount 1;


### PR DESCRIPTION
This is in response to issue https://github.com/rstudio/shiny-server/issues/287, and brings this paragraph of the open-source doc to match the Pro doc. 
Companion to pull request https://github.com/rstudio/shiny-server-pro/pull/779 on the SSP portion of the documentation.