### PR TITLE
Give user an option to run shiny-server as root

### DIFF
--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -269,7 +269,7 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
     }
 
     if (!switchUser && permissions.isSuperuser())
-      throw new Error("Aborting attempt to launch R process as root");
+      logger.warn("You should not attempt to launch R process as root!");
 
     if (switchUser) {
       executable = 'su';


### PR DESCRIPTION
Currently, if the user runs the process of `shiny-server` in root and defines run_as to root, the shiny-server will abort.
It is possible (and secure) to allow users to run the process in root and run_as root?