### PR TITLE
Install all dependencies before running tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,8 @@ try {
                               """
                           }
                           stage('run tests') {
-                              sh './bin/node ./node_modules/mocha/bin/mocha test'
+                              // Need npm install so npm modules required for testing are available
+                              sh './bin/npm install && ./bin/node ./node_modules/mocha/bin/mocha test'
                           }
                         }
                     }


### PR DESCRIPTION
The tests were failing because the npm modules the tests use weren't available. Doing a regular `npm install` first should solve it, and it shouldn't affect the rpm/deb we build because that should've already happened.