### PR TITLE
Add 'status' support to debian init.d script

### DIFF
--- a/config/init.d/debian/shiny-server
+++ b/config/init.d/debian/shiny-server
@@ -79,6 +79,9 @@ case "$1" in
 		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
 	esac
 	;;
+  status)
+          status_of_proc -p "$DAEMON" "$NAME" && exit 0 || exit $?
+	  ;;
   restart|force-reload)
 	log_daemon_msg "Restarting $DESC" "$NAME"
 	do_stop
@@ -98,7 +101,7 @@ case "$1" in
 	esac
 	;;
   *)
-	echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
 	exit 3
 	;;
 esac


### PR DESCRIPTION
Currently doing a status on shiny-server service return [?]