### PR TITLE
Stop monitoring R stdout after expected data is received

### DIFF
--- a/R/SockJSAdapter.R
+++ b/R/SockJSAdapter.R
@@ -238,6 +238,7 @@ if (is.na(port)) {
   attr(port, 'mask') <- strtoi('0077', 8)
 }
 cat(paste("\nStarting Shiny with process ID: '",Sys.getpid(),"'\n", sep=""))
+cat("==END==\n")
 
 if (identical(Sys.getenv('SHINY_MODE'), "shiny")){
   runApp(Sys.getenv('SHINY_APP'),port=port,launch.browser=FALSE)

--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -56,6 +56,7 @@ function spawnUserLog_p(pw, appSpec, endpoint, logFilePath, workerId) {
       var err = "Failed to create log file: " + logFilePath +", " + mode;
       logger.error(err);
       prom.reject(err);
+      return;
     }
 
     // Have R do the logging
@@ -350,7 +351,8 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
         appSpec.settings.appDefaults.sanitizeErrors + '\n' +
         appSpec.settings.appDefaults.bookmarkStateDir + '\n'
       );
-      self.$proc.stdout.pipe(split()).on('data', function(line){
+      var stdoutSplit = self.$proc.stdout.pipe(split());
+      stdoutSplit.on('data', function stdoutSplitListener(line){
         var match = null;
         if (line.match(/^Starting Shiny with process ID: '(\d+)'$/)){
           var pid = parseInt(
@@ -366,6 +368,9 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
         } else if (match = line.match(/^rmarkdown version: (\d+)\.(\d+)\.(\d+)(\.(\d+))?$/)){
           logger.trace("Using rmarkdown version: " + match[1] + "." + match[2] + 
               "." + match[3] + ((match[5])?"."+match[5]:""));
+        } else if (match = line.match(/^==END==$/)){
+          stdoutSplit.off('data', stdoutSplitListener);
+          logger.trace("Closing backchannel");
         }
       });
     })


### PR DESCRIPTION
shiny-server consumes R processes' stdout forever. There's no reason to do this once the information we're looking for has been detected.