### PR TITLE
Simplify usage of `disable_protocols`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@ shiny-server 1.5.13
 
 * Upgrade dependencies to latest versions.
 
+* The `disable_protocols` directive now has `streaming` and `polling` options
+  for easily disabling families of protocols.
+
 shiny-server 1.5.12
 --------------------------------------------------------------------------------
 

--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -218,8 +218,8 @@ disable_websockets {
 }
 
 disable_protocols {
-  desc "Disable some of the SockJS protocols used to establish a connection between your users and your server. Some network configurations cause problems with particular protocols; this option allows you to disable those.";
-  param String names... "The protocol(s) to disable. Available protocols are: 'websocket', 'xdr-streaming', 'xhr-streaming', 'iframe-eventsource', 'iframe-htmlfile', 'xdr-polling', 'xhr-polling', 'iframe-xhr-polling', 'jsonp-polling'";
+  desc "Disable some of the SockJS protocols used to establish a connection between your users and your server. Some network configurations cause problems with particular protocols; this option allows you to disable those. If your Shiny apps are loading but are unable to show outputs or maintain connections, try disabling 'websocket', then both 'websocket' and 'streaming'. If problems persist, it's unlikely that they are caused by compatibilities with SockJS, as the only remaining protocols are 'polling' which should work well with just about any reasonable HTTP proxy, load balancer, VPN, etc.";
+  param String names... "The protocol(s) to disable. Available protocols are: 'websocket', 'xdr-streaming', 'xhr-streaming', 'iframe-eventsource', 'iframe-htmlfile', 'xdr-polling', 'xhr-polling', 'iframe-xhr-polling', 'jsonp-polling'. You can also specify 'streaming' to disable all protocols that use streaming, and 'polling' to disable all protocols that use polling.";
   at $ server location;
   maxcount 1;
 }

--- a/lib/router/config-router-util.js
+++ b/lib/router/config-router-util.js
@@ -26,6 +26,11 @@ var ALL_PROTOCOLS = {
   "jsonp-polling": true
 };
 
+var META_PROTOCOLS = {
+  "streaming": ["xdr-streaming", "iframe-htmlfile", "xhr-streaming", "iframe-eventsource"],
+  "polling": ["jsonp-polling", "xdr-polling", "iframe-xhr-polling", "xhr-polling"]
+};
+
 /** A set of utility helper functions for config routers.
  */
 
@@ -94,13 +99,19 @@ function parseApplication(settings, locNode, provideDefaults){
 
   var disableProtocolsNode = locNode.getOne('disable_protocols', true);
   if (disableProtocolsNode && disableProtocolsNode.values.names) {
-    appSettings.disableProtocols = disableProtocolsNode.values.names;
-    appSettings.disableProtocols.forEach(function(name) {
-      if (!ALL_PROTOCOLS[name]) {
-        throwForNode(disableProtocolsNode,
-          new Error("Unrecognized protocol " + name));
-      }
-    });
+    appSettings.disableProtocols = disableProtocolsNode.values.names.reduce(
+      (accum, name) => {
+        if (ALL_PROTOCOLS[name]) {
+          return accum.concat([name]);
+        } else if (META_PROTOCOLS[name]) {
+          return accum.concat(META_PROTOCOLS[name]);
+        } else {
+          throwForNode(disableProtocolsNode,
+            new Error("Unrecognized protocol " + name));
+        }
+      },
+      []
+    );
   }
   if (locNode.getValues('disable_websockets').val){
     appSettings.disableProtocols.push('websocket');


### PR DESCRIPTION
Fixes #418 

## Testing notes

Try the new `disable_protocols` values of `streaming` and `polling`. See what effect they have on the available protocols (you can see them by showing the Protocol Selector in a Shiny app).

You can tell which protocols are supposed to be streaming or polling by looking at the table here:
https://github.com/sockjs/sockjs-client#supported-transports-by-browser-html-served-from-http-or-https