### PR TITLE
Allow sending of R logs to stderr

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,11 @@ shiny-server 1.5.13
 * The `disable_protocols` directive now has `streaming` and `polling` options
   for easily disabling families of protocols.
 
+* Now able to redirect R logs to the main shiny-server process's stderr, which
+  is useful for containerized deployments and other scenarios where log files on
+  disk are inconvenient to access. Enable this functionality by setting the
+  environment variable `SHINY_LOG_STDERR` to a non-empty value.
+
 shiny-server 1.5.12
 --------------------------------------------------------------------------------
 

--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -107,7 +107,7 @@ redirect {
 }
 
 log_dir {
-  desc "Directs the application to write error logs to the specified directory. Only applies to location scopes that are configured with `app_dir` or `site_dir`, as `user_apps` (autouser) always writes error logs to `~/ShinyApps/log`.";
+  desc "Directs the application to write error logs to the specified directory. Only applies to location scopes that are configured with `app_dir` or `site_dir`, as `user_apps` (autouser) always writes error logs to `~/ShinyApps/log`. In addition, starting in v1.5.13 you can set the environment variable `SHINY_LOG_STDERR` to any non-empty value to instruct Shiny Server to emit stderr output from Shiny apps to the main process's own stderr.";
   param String path "The path to which application log files should be written";
   at $ server location;
   maxcount 1;

--- a/lib/worker/app-worker.js
+++ b/lib/worker/app-worker.js
@@ -35,6 +35,8 @@ var posix = require('../../build/Release/posix');
 var rprog = process.env.R || 'R';
 var scriptPath = paths.projectFile('R/SockJSAdapter.R');
 
+const STDERR_PASSTHROUGH = !!process.env["SHINY_LOG_STDERR"];
+
 function exists_p(path) {
   var defer = Q.defer();
   fs.exists(path, function(exists) {
@@ -133,19 +135,26 @@ function launchWorker_p(appSpec, pw, endpoint, logFilePath, workerId) {
             logger.error('Error attempting to change permissions on log file at ' + logFilePath + ': ' + err.message);
         });
 
+        // We got a file descriptor and have chowned the file which is great, but
+        // we actually want a writeStream for this file so we can handle async
+        // writes more cleanly.
+        var writeStream = fs.createWriteStream(null,
+          {fd: logStream, flags: 'w', mode: mode })
+
+        // If we have problems writing to writeStream, report it at most once.
+        var warned = false;
+        writeStream.on('error', function(err) {
+          if (!warned) {
+            warned = true;
+            logger.warn('Error writing to log stream: ', err);
+          }
+        });
+
         // Create the worker; when it exits (or fails to start), close
         // the logStream.
-        var worker = new AppWorker(appSpec, endpoint, logStream, workerId, 
+        var worker = new AppWorker(appSpec, endpoint, writeStream, workerId, 
           pw.home);
-        worker.getExit_p()
-        .fin(function() {
-          fs.close(logStream, function(err) {
-            if (err)
-              logger.error("Couldn't close logStream: " + err.message);
-          });
-        })
-        .eat();
-
+          
         return worker;
       });
     } else {
@@ -318,7 +327,7 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
     })
     .then(function() {
       self.$proc = child_process.spawn(executable, args, {
-        stdio: ['pipe', 'pipe', logStream],
+        stdio: ['pipe', 'pipe', 'pipe'],
         cwd: appSpec.appDir,
         env: map.compact({
           'HOME' : home,
@@ -373,12 +382,39 @@ var AppWorker = function(appSpec, endpoint, logStream, workerId, home) {
           logger.trace("Closing backchannel");
         }
       });
+      self.$proc.stderr
+        .on('error', function(e) {
+          logger.error('Error on proc stderr: ' + e);
+        })
+        .pipe(split())
+          .on('data', function(line){
+            if (STDERR_PASSTHROUGH) {
+              logger.info(`[${appSpec.appDir}:${self.$pid}] ${line}`);
+            }
+            // Ensure that we, not R, are supposed to be handling logging.
+            if (logStream !== 'ignore'){
+              logStream.write(line+'\n');
+            }
+          })
+          .on('end', function() {
+            if (logStream !== 'ignore') {
+              logStream.end();
+            }
+          });
     })
     .fail(function(err){
       // An error occured spawning the process, could be we tried to launch a file
       // instead of a directory.
       logger.warn(err.message);
       
+      if (!self.$proc) {
+        // We never got around to starting the process, so the normal code path
+        // that closes logStream won't run.
+        if (logStream !== 'ignore') {
+          logStream.end();
+        }
+      }
+
       self.$dfEnded.resolve({code: -1, signal: null});
     })
     .done();


### PR DESCRIPTION
## Testing notes

Add environment variable `SHINY_LOG_STDERR=1` before running shiny-server. You can do this in a couple of ways:

When running from the command line, you can just do `sudo SHINY_LOG_STDERR=1 shiny-server`.

From systemd, edit `/etc/systemd/system/shiny-server.service`, adding the line `Environment=SHINY_LOG_STDERR=1` under the `[Service]` heading. Then run `systemctl daemon-reload`, then `systemctl restart shiny-server`.