### PR TITLE
path must be full qualified

### DIFF
--- a/config/init.d/debian/shiny-server
+++ b/config/init.d/debian/shiny-server
@@ -18,7 +18,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="shiny server"
 NAME=shiny-server
-DAEMON=shiny-server
+DAEMON=/usr/bin/shiny-server
 SCRIPTNAME=/etc/init.d/shiny-server
 
 # Exit if the package is not installed


### PR DESCRIPTION
otherwise debian 10 says: 
$ sudo /etc/init.d/shiny-server start
start-stop-daemon: unable to stat //shiny-server (No such file or directory)

see
https://askubuntu.com/questions/900603/getting-unable-to-stat-bundle-no-such-file-or-directory-even-though-the-fi