### PR TITLE
Remove cloudfront SockJS reference which is broken

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
+shiny-server 1.5.14
+--------------------------------------------------------------------------------
+
+* `iframe` based SockJS protocols were using a CDN copy of a JS library that no
+  longer exists, causing breakage. Now an internal copy is used. (The `iframe`
+  SockJS protocols should not be needed for browsers that are supported by Shiny
+  Server these days; if you ran into this problem, please revisit the value
+  you're using for `disable_protocols`, and especially try removing
+  `xhr-polling` from the disabled list.)
+
 shiny-server 1.5.13
 --------------------------------------------------------------------------------
 

--- a/lib/proxy/sockjs.js
+++ b/lib/proxy/sockjs.js
@@ -38,7 +38,7 @@ function createServer(router, schedulerRegistry, heartbeatDelay, disconnectDelay
   // between the SockJS server connection and the worker websocket connection.
   var sockjsServer = sockjs.createServer({
     // TODO: make URL configurable
-    sockjs_url: '//d1fxtkz8shb9d2.cloudfront.net/sockjs-0.3.min.js',
+    sockjs_url: '../../__assets__/sockjs-0.3.4.min.js',
     prefix: '.*/__sockjs__(/[no]=\\w+)?',
     log: function() {},
     heartbeat_delay: heartbeatDelay,


### PR DESCRIPTION
This SockJS URL has apparently been broken for some time. We haven't noticed because it's almost never used; in almost every case, we load sockjs.min.js using our own internal copy. It's only the iframe-based protocols (which have been obsolete since IE10) that reference this URL.

In the future we should try to simplify the suite of transports to just websocket, xhr-streaming, xhr-polling, and *maybe* one more. However, we'll need to take existing `disable_protocol` directives into account, and try to figure out what their intent was.