### PR TITLE
CSS: align-left to the "disconnected from server" message

### DIFF
--- a/assets/shiny-server.css
+++ b/assets/shiny-server.css
@@ -10,6 +10,7 @@ body.disconnected {
 
 #ss-connect-dialog {
   opacity: 1 !important;
+  text-align: left;
   padding: 1em;
   position: fixed;
   bottom: 50px;


### PR DESCRIPTION
The "disconnected from server" grey box doesn't explicitly set a text justification. When a page's body tag has a center align, the message gets center aligned within the box, which looks strange. I think the message should always look the same.