### PR TITLE
Fix persistent launch error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 shiny-server 1.5.16
 --------------------------------------------------------------------------------
 
+* Fix an issue where a failure in a certain phase of R process launching would
+  result in a broken process being treated as a normal process, and repeatedly
+  used to (unsuccessfully) serve new clients.
+
 * Upgrade Node.js to 12.20.0.
 
 shiny-server 1.5.15

--- a/lib/scheduler/scheduler.js
+++ b/lib/scheduler/scheduler.js
@@ -143,6 +143,10 @@ function connectEndpoint_p(endpoint, timeout, shouldContinue) {
     var logFilePath = null;
     var doReject = function(err) {
       err.consoleLogFile = logFilePath;
+      if (self.$workers[workerId]) {
+        logger.trace("Subprocess failed to start, removing worker entry");
+        delete self.$workers[workerId];
+      }
       defer.reject(err);
     };
     // Once defer is fulfilled, doReject is essentially a no-op. The following


### PR DESCRIPTION
In lib/scheduler/scheduler.js there's a call to posix.getpwnam. If an error is raised there, cleanup is incomplete; in particular, the workerEntry for the new (now failed) worker is not removed. This broken worker is then reused as if it is working, returning the same error to every new client.

This fix simply removes the workerEntry.

(For context: I found this due to an SSP customer having a mysterious `EPIPE` error occur right at this spot in the code. I don't yet know what's causing the `EPIPE`, but this fixes the secondary effect: whatever app triggered the `EPIPE` would constantly return that same error message after that point, until the shiny-server process was restarted.)

## Testing notes

I can't think of a way to trigger an error at the exact point where it needs to be triggered for this fix to be relevant. In my own testing, I had to just modify the source code to throw an error at that point.

I went so far as to try deleting `/etc/passwd` while Shiny Server is running and WOW do I recommend that you **NOT** do that!