### PR TITLE
Fix security vulnerability

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 shiny-server 1.5.16
 --------------------------------------------------------------------------------
 
+* SECURITY: Fix a serious vulnerability where maliciously formed URLs can result
+  in source code disclosure. Please upgrade as soon as possible!
+
 * Fix an issue where a failure in a certain phase of R process launching would
   result in a broken process being treated as a normal process, and repeatedly
   used to (unsuccessfully) serve new clients.

--- a/lib/router/directory-router.js
+++ b/lib/router/directory-router.js
@@ -76,7 +76,12 @@ function DirectoryRouter(root, runas, dirIndex, prefix, logdir, settings,
       return Q.resolve(true);
     }
 
-    return this.$findShinyDir_p(suffix)
+    var candidates = extractUnescapedDirs(suffix);
+    if (!candidates || candidates.length == 0) {
+      return Q.resolve(null);
+    }
+
+    return this.$findShinyDir_p(candidates)
     .fail(function(err) {
       logger.error('Error finding Shiny dir: ' + err.message);
       return null;
@@ -260,15 +265,10 @@ function DirectoryRouter(root, runas, dirIndex, prefix, logdir, settings,
     });
   };
 
-  this.$findShinyDir_p = function(pathname) {
+  // @param candidates Return value from extractUnescapedDirs. Must not be null.
+  this.$findShinyDir_p = function(candidates) {
     var self = this;
 
-    if (pathname.length < 1)
-      return Q.resolve(null);
-    if (pathname.charAt(0) != '/')
-      return Q.resolve(null);
-
-    var candidates = extractUnescapedDirs(pathname);
     if (!candidates || candidates.length == 0)
       return Q.resolve(null);
 
@@ -405,6 +405,13 @@ function DirectoryRouter(root, runas, dirIndex, prefix, logdir, settings,
  * a path.
  */
 function extractUnescapedDirs(p) {
+  if (p.length < 1) {
+    return null;
+  }
+  if (p.charAt(0) != '/') {
+    return null;
+  }
+
   var re = /\/|$/g;
   var m;
 


### PR DESCRIPTION
The directory-router has two ways of serving a URL: by proxying to
a Shiny app, or by serving a static file (or directory listing) from
disk. Previously, the URL parsing logic for the two code paths was
totally different, and the former code path was more carefully coded
against possibly malicious or malformed URLs. Unfortunately, URLs
that were rejected by the former code path were then passed on to
the latter code path.

This change ensures that failure to pass URL checks cause the router
to give up on servicing the request (leading to a 404, probably).