### PR TITLE
Adding support for running as :ANY: user

### DIFF
--- a/lib/router/config-router.js
+++ b/lib/router/config-router.js
@@ -76,7 +76,7 @@ function checkPermissions(conf) {
 
   // If we got here, we're not running as root
 
-  if (users.length) {
+  if (users.length && !users[0].values.users.includes(':ANY:') ) {
     var userLine = users[0].values.users;
     throwForNode(users[0],
         new Error("The user '" + permissions.getProcessUser() + "' does not have permissions to run applications as one of the users in '" + 
@@ -370,6 +370,10 @@ function createSiteDir(locNode, node, settings) {
   if (!runas || runas.length == 0)
     throwForNode(locNode, new Error(
         'Required "run_as" directive not present or has no users.'));
+
+  if (runas.includes(':ANY:'))
+    logger.trace('Running as :ANY: user.');
+    runas = permissions.getProcessUser();
 
   var logdir = locNode.getValues('log_dir').path;
   if (!logdir)


### PR DESCRIPTION
This is useful in Kubernetes environments where the uid is provided by the
platform.  In environments with user namespacing even if the container thinks
it is running as root it can be mapped to a non-root user in the host OS.