### PR TITLE
Update shiny-server.service

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ try {
     timestamps {
         def containers = [
           [os: 'ubuntu-14.04', arch: 'x86_64'],
-          [os: 'centos6.3', arch: 'x86_64']
+          [os: 'centos7', arch: 'x86_64']
         ]
         def parallel_containers = [:]
         for (int i = 0; i < containers.size(); i++) {

--- a/docker/jenkins/Dockerfile.centos7
+++ b/docker/jenkins/Dockerfile.centos7
@@ -1,11 +1,11 @@
-FROM centos:6
+FROM centos:7
 MAINTAINER Chad Barraford <chad@rstudio.com>
 
 # EPEL
 RUN yum -y install epel-release
 
 # RPMForge
-RUN     rpm -Uvh http://mirror.chpc.utah.edu/pub/repoforge/redhat/el6/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm
+RUN     rpm -Uvh http://mirror.chpc.utah.edu/pub/repoforge/redhat/el7/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el7.rf.x86_64.rpm
 
 # SSH
 EXPOSE 22


### PR DESCRIPTION
According to https://github.com/rstudio/shiny-server/wiki/Building-Shiny-Server-from-Source , the executable file is located at /usr/local/shiny-server/bin/shiny-server and we made a link to /usr/bin/shiny-server. This is why, I think the service should execute /usr/bin/shiny-server instead of /opt/shiny-server/bin/shiny-server