### PR TITLE
SingleAppRouter.getAppSpec_p does too much work before matching URL

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+shiny-server 1.5.17
+--------------------------------------------------------------------------------
+
+* `app_dir` config directives pointing to missing or unreadable directories on
+  disk were causing errors during routing, even for requests intended for
+  unrelated apps.
+
 shiny-server 1.5.16
 --------------------------------------------------------------------------------
 

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -215,6 +215,24 @@ function SingleAppRouter(appdir, runas, prefix, logDir, settings) {
     
     var self = this;
 
+    var reqUrl = url.parse(req.url);
+    var m = self.$rePath.exec(reqUrl.pathname);
+    if (!m)
+      return Q.resolve(null);
+
+    if (!m[1]) {
+      if (res) {
+        res.writeHead(301, {
+          'Location': reqUrl.pathname + '/' + (reqUrl.search || '')
+        });
+        res.end();
+        return Q.resolve(true);
+      } else {
+        // SockJS case, this is not expected
+        return Q.resolve(null);
+      }
+    }
+
     // Creates a /shallow/ copy of the settings object. So we can independently
     // mutate top-level properties (but not nested objects) without affecting 
     // the class variable.
@@ -282,23 +300,6 @@ function SingleAppRouter(appdir, runas, prefix, logDir, settings) {
         // No app found.
       }
 
-      var reqUrl = url.parse(req.url);
-      var m = self.$rePath.exec(reqUrl.pathname);
-      if (!m)
-        return null;
-
-      if (!m[1]) {
-        if (res) {
-          res.writeHead(301, {
-            'Location': reqUrl.pathname + '/' + (reqUrl.search || '')
-          });
-          res.end();
-          return true;
-        } else {
-          // SockJS case, this is not expected
-          return null;
-        }
-      }
       return appSpec;
     });
   }


### PR DESCRIPTION
A customer reported that a broken `app_dir` (e.g. root directory
that doesn't exist) caused many apps on the server to be broken,
not just the broken app itself. This is because during routing
(i.e. getAppSpec_p()), the locations are tried one after another
to see if they match the request URL. In the case of app_dir,
the SingleAppRouter.getAppSpec_p method was doing a bunch of
directory reading before even looking to see if the URL was
a match; if that directory reading failed, the request would
see a 500 error or whatever.

With this change, an error should only be seen when a broken
app is actually being requested.

## Testing notes

Add a section like this to the config file:

```
location /app {
  app_dir /blah;
  log_dir /var/log/shiny-server;
}
```

This should be done within the `server { }` directive, and it needs to come before any sibling `location` directives. For example:

```
# Instruct Shiny Server to run applications as the user "shiny"
run_as shiny;

# Define a server that listens on port 3838
server {
  listen 3838;

  location /app {
    app_dir blah;
    log_dir /var/log/shiny-server;
  }

  # Define a location at the base URL
  location / {

    # Host the directory of Shiny Apps stored in this directory
    site_dir /srv/shiny-server;

    # Log all Shiny output to files in this directory
    log_dir /var/log/shiny-server;

    # When a user visits the base URL rather than a particular application,
    # an index of the applications available in this directory will be shown.
    directory_index on;
  }
}
```

Before this fix, simply visiting the server's root URL would give you an error like:

> **An error has occurred**
> Invalid application configuration.
> `ENOENT: no such file or directory, scandir 'blah'`

After the fix, everything works fine _unless_ you navigate to the broken location, at which time you see the above error.