### PR TITLE
Squelch nan-related compiler warning; upgrade shiny-server-client

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2143,8 +2143,8 @@
       "dev": true
     },
     "shiny-server-client": {
-      "version": "github:rstudio/shiny-server-client#d63e91ef06ce3de04761912590decd63c719cdb5",
-      "from": "github:rstudio/shiny-server-client#d63e91ef06ce3de04761912590decd63c719cdb5",
+      "version": "github:rstudio/shiny-server-client#5ee5aac7194b42d495eba9bde89d899c683af181",
+      "from": "github:rstudio/shiny-server-client#v1.2.0",
       "requires": {
         "inherits": "^2.0.4",
         "pinkyswear": "~2.2"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "q": "^1.5.1",
     "qs": "^6.10.1",
     "send": "^0.17.0",
-    "shiny-server-client": "github:rstudio/shiny-server-client#d63e91ef06ce3de04761912590decd63c719cdb5",
+    "shiny-server-client": "github:rstudio/shiny-server-client#v1.2.0",
     "sockjs": "^0.3.21",
     "split": "^1.0.1",
     "stable": "^0.1.8",

--- a/src/posix.cc
+++ b/src/posix.cc
@@ -10,7 +10,19 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
+
+// See https://github.com/nodejs/nan/issues/807#issuecomment-581536991
+#if defined(__GNUC__) && __GNUC__ >= 8
+#define DISABLE_WCAST_FUNCTION_TYPE _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")
+#define DISABLE_WCAST_FUNCTION_TYPE_END _Pragma("GCC diagnostic pop")
+#else
+#define DISABLE_WCAST_FUNCTION_TYPE
+#define DISABLE_WCAST_FUNCTION_TYPE_END
+#endif
+
+DISABLE_WCAST_FUNCTION_TYPE
 #include <nan.h>
+DISABLE_WCAST_FUNCTION_TYPE_END
 #include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
@@ -274,4 +286,6 @@ NAN_MODULE_INIT(Initialize) {
   Nan::Export(target, "getgrnam", GetGrNam);
   Nan::Export(target, "acquireRecordLock", AcquireRecordLock);
 }
+DISABLE_WCAST_FUNCTION_TYPE
 NODE_MODULE(posix, Initialize)
+DISABLE_WCAST_FUNCTION_TYPE_END


### PR DESCRIPTION
The warnings are the same as this issue: https://github.com/nodejs/nan/issues/807