### PR TITLE
Fix jsonp-polling unresponsiveness (similar to #499)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2324,8 +2324,8 @@
       }
     },
     "sockjs-client": {
-      "version": "github:jcheng5/sockjs-client#60024c7c57e0195e3796c64ec539606873cd1f8d",
-      "from": "github:jcheng5/sockjs-client#v1.5.2-jcheng5",
+      "version": "github:jcheng5/sockjs-client#dafe26bec4d0c7edf5cca256d8bcd86514a84def",
+      "from": "github:jcheng5/sockjs-client#v1.5.2.2-jcheng5",
       "requires": {
         "debug": "^3.2.6",
         "eventsource": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "send": "^0.17.0",
     "shiny-server-client": "github:rstudio/shiny-server-client#v1.2.0",
     "sockjs": "^0.3.21",
-    "sockjs-client": "github:jcheng5/sockjs-client#v1.5.2-jcheng5",
+    "sockjs-client": "github:jcheng5/sockjs-client#v1.5.2.2-jcheng5",
     "split": "^1.0.1",
     "stable": "^0.1.8",
     "underscore": "^1.13.1"


### PR DESCRIPTION
## Testing notes

See the example in #499. That PR did not fix jsonp-polling, this one does.

The actual code change is in my fork of sockjs-client, [here](https://github.com/jcheng5/sockjs-client/commit/e10d608cc444d554de5b4e861e7c54bfcbb4084f).