### PR TITLE
Recognize qmd extension as quarto

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,17 @@
+shiny-server 1.5.20
+--------------------------------------------------------------------------------
+
+* Support hosting of prerendered Quarto `server: shiny` interactive documents.
+  Prerender the document before uploading by running `quarto serve index.qmd`,
+  then deploy the generated index.html, index_files directory, and the source
+  index.qmd together to be served by Shiny Server.
+
+shiny-server 1.5.19
+--------------------------------------------------------------------------------
+
+* Support hosting of Shiny for Python apps. For more information, see:
+  https://shiny.rstudio.com/py/docs/deploy.html
+
 shiny-server 1.5.18
 --------------------------------------------------------------------------------
 

--- a/R/SockJSAdapter.R
+++ b/R/SockJSAdapter.R
@@ -252,6 +252,11 @@ cat("==END==\n")
 if (identical(Sys.getenv('SHINY_MODE'), "shiny")){
   runApp(Sys.getenv('SHINY_APP'),port=port,launch.browser=FALSE)
 } else if (identical(Sys.getenv('SHINY_MODE'), "rmd")){
+  # If we might be rendering Quarto docs, it's important to suppress the
+  # prerender step (see https://github.com/rstudio/shiny-server/pull/531)
+  if (length(list.files(Sys.getenv('SHINY_APP'), pattern = "*.qmd")) > 0) {
+    Sys.setenv(RMARKDOWN_RUN_PRERENDER = "0")
+  }
   library(rmarkdown)
   rmarkdown::run(file=NULL, dir=Sys.getenv('SHINY_APP'),
     shiny_args=list(port=port,launch.browser=FALSE), auto_reload=FALSE)

--- a/lib/core/url-util.js
+++ b/lib/core/url-util.js
@@ -12,6 +12,6 @@
  */
 
 function isAppPagePath(path) {
-  return path && (path === "/" || path.match(/\.rmd$/i));
+  return path && (path === "/" || path.match(/\.[rq]md$/i));
 }
 exports.isAppPagePath = isAppPagePath;

--- a/lib/router/directory-router.js
+++ b/lib/router/directory-router.js
@@ -295,13 +295,13 @@ function DirectoryRouter(root, runas, dirIndex, prefix, logdir, settings,
                   return /^app\.r$/i.test(entry);
                 });
                 var rmd = _.find(entries, function(entry) {
-                  return /\.rmd$/i.test(entry);
+                  return /\.[rq]md$/i.test(entry);
                 });
                 var pyApp = _.find(entries, function(entry) {
                   return /^app\.py$/.test(entry);
                 });
                 var indexRmd = _.find(entries, function(entry) {
-                  if (/^index\.rmd$/i.test(entry)){
+                  if (/^index\.[rq]md$/i.test(entry)){
                     return entry;
                   }
                   return false;

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -252,10 +252,10 @@ function SingleAppRouter(appdir, runas, prefix, logDir, settings) {
         return /^app\.r$/i.test(entry);
       });
       var rmd = _.find(files, function(entry) {
-        return /\.rmd$/i.test(entry);
+        return /\.[rq]md$/i.test(entry);
       });
       var indexRmd = _.find(files, function(entry) {
-        if (/^index\.rmd$/i.test(entry)){
+        if (/^index\.[rq]md$/i.test(entry)){
           return entry;
         }
         return false;


### PR DESCRIPTION
This PR allows Shiny Server to treat .qmd files the same as .Rmd files. The only difference is that .qmd files _only_ work in prerendered mode; we go out of our way to prevent document rendering from occurring in any directory that contains .qmd.

## Testing notes

Using this file:
````
---
title: "Old Faithful"
format: html
server: shiny
---

```{r}
sliderInput("bins", "Number of bins:", 
            min = 1, max = 50, value = 30)
plotOutput("distPlot")
```

```{r}
#| context: server
output$distPlot <- renderPlot({
  x <- faithful[, 2]  # Old Faithful Geyser data
  bins <- seq(min(x), max(x), length.out = input$bins + 1)
  hist(x, breaks = bins, col = 'darkgray', border = 'white')
})
```
````

### Scenario 1: Prerendered

1. Save the document above on a local machine with Quarto installed, with the filename `index.qmd`.
2. In the directory with `index.qmd` run `quarto serve index.qmd`, this should cause a render.
3. Deploy `index.qmd`, `index.html`, and `index_files/` into a Shiny Server site subdirectory.

**Expected:** You can load up the app and interact with it.

### Scenario 2: Not prerendered

1. Put the document above in a Shiny Server site subdirectory as `index.qmd`, with no other contents.

**Expected:** The app should completely fail to load (no UI or anything, just an error message). The app log should say something about "Prerendered HTML file not found" or something.

### Scenario 3: Filename other than index.qmd

1. Save the document above on a local machine with Quarto installed, with the filename `page.qmd`.
2. In the directory with `page.qmd` run `quarto serve page.qmd`, this should cause a render.
3. Deploy `page.qmd`, `page.html`, and `page_files/` into a Shiny Server site subdirectory.
4. In the same site subdirectory, create `index.html`:
  ```html
  <!DOCTYPE html>
  <html>
    <body>
      <a href="page.qmd">Link to app</a>
    </body>
  </html>
  ```

**Expected:** Navigating to the subdirectory should produce a simple page with "Link to app"; clicking that link should bring you to a working app.

### Scenarios 4-6

Same as above, but use `app_dir` instead of `site_dir` directive in the SSOS config file.