### PR TITLE
Increase server->client message size limit

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+shiny-server 1.5.21
+--------------------------------------------------------------------------------
+
+* Increase the maximum allowable WebSocket message size that can be sent from
+  the Shiny server to the browser, from 64MB to 512MB. (The maximum message size
+  allowed from the browser to the server remains 64MB.)
+
 shiny-server 1.5.20
 --------------------------------------------------------------------------------
 

--- a/lib/transport/tcp.js
+++ b/lib/transport/tcp.js
@@ -126,7 +126,21 @@ util.inherits(Endpoint, BaseEndpoint);
         headers: _.extend(
           {'shiny-shared-secret': this.getSharedSecret()},
           headers || {}
-        )
+        ),
+        // This controls the maximum frame length we will accept from the
+        // R process (to be relayed to the client). 0x1fffffe8 is the
+        // longest we can make it without crashing the Node process by
+        // exceeding the maximum length for a string. It's possible large
+        // messages could be used to starve the server of memory, but in
+        // this case the malicious party would have to be the app author,
+        // who would have easier ways of causing out-of-memory situations.
+        //
+        // Note that the maximum length of object we will accept from the
+        // client remains the default of ~64MB; increasing (or making a
+        // configurable option of) that limit would have to happen in the
+        // sockjs.createServer() call in this file, by passing an option
+        // faye_server_options: { maxLength: xxxx }.
+        maxLength: 0x1fffffe8
       }
     );
   };


### PR DESCRIPTION
Fixes https://github.com/rstudio/shiny/issues/3086 (or at least significantly lifts the ceiling, from 64MB to 512MB). See https://github.com/rstudio/shiny/issues/3086#issuecomment-703802470 for a repro tool.