### PR TITLE
Use new Google tag-style anayltics code

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ shiny-server 1.5.21
   the Shiny server to the browser, from 64MB to 512MB. (The maximum message size
   allowed from the browser to the server remains 64MB.)
 
+* Migrate google_analytics_id implementation from Universal Analytics to modern
+  gtag.js.
+
 * Upgrade Node.js to 16.20.0.
 
 shiny-server 1.5.20

--- a/R/SockJSAdapter.R
+++ b/R/SockJSAdapter.R
@@ -182,7 +182,11 @@ local({
 
    gaTrackingCode <- ''
    if (nzchar(Sys.getenv('SHINY_GAID'))) {
-      gaTrackingCode <- HTML(sprintf("<script type=\"text/javascript\">
+      gaID <- Sys.getenv('SHINY_GAID')
+      if (grepl('^UA-', gaID) {
+        # gaID is Universal Analytics style ID, deprecated 2023-07-01
+        # https://support.google.com/analytics/answer/11583528?hl=en&sjid=7400348922365190905-NA
+        gaTrackingTemplate <- "<script type=\"text/javascript\">
 
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', '%s']);
@@ -194,7 +198,19 @@ local({
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 
-</script>", Sys.getenv('SHINY_GAID')))
+</script>"
+        gaTrackingCode <- HTML(sprintf(gaTrackingTemplate, gaID))
+      } else {
+        gaTrackingTemplate <- "<!-- Google tag (gtag.js) -->
+<script async src=\"https://www.googletagmanager.com/gtag/js?id=%s\"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '%s');
+</script>"
+        gaTrackingCode <- HTML(sprintf(gaTrackingTemplate, gaID, gaID))
+      }
    }
 
    inject <- paste(

--- a/R/SockJSAdapter.R
+++ b/R/SockJSAdapter.R
@@ -183,7 +183,7 @@ local({
    gaTrackingCode <- ''
    if (nzchar(Sys.getenv('SHINY_GAID'))) {
       gaID <- Sys.getenv('SHINY_GAID')
-      if (grepl('^UA-', gaID) {
+      if (grepl('^UA-', gaID)) {
         # gaID is Universal Analytics style ID, deprecated 2023-07-01
         # https://support.google.com/analytics/answer/11583528?hl=en&sjid=7400348922365190905-NA
         gaTrackingTemplate <- "<script type=\"text/javascript\">

--- a/config/shiny-server-rules.config
+++ b/config/shiny-server-rules.config
@@ -129,7 +129,7 @@ members_of {
 
 google_analytics_id {
   desc "Configure Google Analytics tracking code to be inserted in Shiny application pages.";
-  param String gaid "The Google tracking ID, for example, UA-18988-1";
+  param String gaid "The Google tag ID, for example, G-123ABCD";
   at $ server location;
   internal true;  # Probably shouldn't document this since it will change soon
 }

--- a/python/SockJSAdapter.py
+++ b/python/SockJSAdapter.py
@@ -113,12 +113,12 @@ class ShinyInjectHeadMiddleware:
             else:
                 gaTrackingCode = """
                     <!-- Google tag (gtag.js) -->
-                    <script async src=\"https://www.googletagmanager.com/gtag/js?id=%s\"></script>
+                    <script async src=\"https://www.googletagmanager.com/gtag/js?id={0}\"></script>
                     <script>
                     window.dataLayer = window.dataLayer || [];
-                    function gtag(){dataLayer.push(arguments);}
+                    function gtag(){{dataLayer.push(arguments);}}
                     gtag('js', new Date());
-                    gtag('config', '%s');
+                    gtag('config', '{1}');
                     </script>
                     """.format(
                     gaID, gaID

--- a/python/SockJSAdapter.py
+++ b/python/SockJSAdapter.py
@@ -88,25 +88,41 @@ class ShinyInjectHeadMiddleware:
         else:
             disable_protocols = ""
 
+        gaTrackingCode = ""
         if input["gaTrackingId"]:
-            gaTrackingCode = """
-    <script type="text/javascript">
+            gaID = input["gaTrackingId"]
+            if gaID[:3] == "UA-":
+                # Deprecated Google Analytics with Universal Analytics ID
+                gaTrackingCode = """
+                    <script type="text/javascript">
 
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', '{0}']);
-    _gaq.push(['_trackPageview']);
+                    var _gaq = _gaq || [];
+                    _gaq.push(['_setAccount', '{0}']);
+                    _gaq.push(['_trackPageview']);
 
-    (function() {{
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    }})();
+                    (function() {{
+                        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+                        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+                    }})();
 
-    </script>""".format(
-                input["gaTrackingId"]
-            )
-        else:
-            gaTrackingCode = ""
+                    </script>
+                    """.format(
+                    gaID
+                )
+            else:
+                gaTrackingCode = """
+                    <!-- Google tag (gtag.js) -->
+                    <script async src=\"https://www.googletagmanager.com/gtag/js?id=%s\"></script>
+                    <script>
+                    window.dataLayer = window.dataLayer || [];
+                    function gtag(){dataLayer.push(arguments);}
+                    gtag('js', new Date());
+                    gtag('config', '%s');
+                    </script>
+                    """.format(
+                    gaID, gaID
+                )
 
         self.script = """  <script src="__assets__/sockjs.min.js"></script>
     <script src="__assets__/shiny-server-client.min.js"></script>


### PR DESCRIPTION
Fixes #469
Fixes #554

[Universal Analytics is going away](https://support.google.com/analytics/answer/11583528?hl=en&sjid=7400348922365190905-NA) and will stop processing data on July 1, 2023. The analytics code for this style of GA tracking uses IDs that start with `UA-`.

Google Analytics users should [switch to Google Analytics 4](https://support.google.com/analytics/answer/10759417?sjid=7400348922365190905-NA), which requires new tracking code that uses [a Google tag](https://support.google.com/analytics/answer/9744165?sjid=7400348922365190905-NA#install-manually&zippy=%2Cin-this-article%2Cinstall-a-google-tag).

This PR follows the [Install the Google tag (gtag.js)](https://developers.google.com/tag-platform/gtagjs/install) article and updates the GA tracking code to use the JavaScript provided there.

For backwards compatibility we detect if the `google_analytics_id` starts with `UA-` and use the older-style tracking in those cases – mostly to aid debugging. I suppose we could also issue a warning – if that's as easy as calling `warning()` (and the Python equivalent) when we detect `UA-` ids I can add that in.