### PR TITLE
Remove `stable` package in favor of native stable sort

### DIFF
--- a/lib/router/config-router.js
+++ b/lib/router/config-router.js
@@ -13,7 +13,6 @@
 // TODO: Drop root whenever possible
 const path = require('path');
 const util = require('util');
-const stable = require('stable');
 const assert = require('assert');
 const _ = require('underscore');
 const iputil = require('../core/iputil');
@@ -156,7 +155,7 @@ Object.defineProperty(ConfigRouter.prototype, "reconnect", {
     });
 
     // Stable sort the scored servers; higher scores at the beginning
-    scored = stable(scored, function(a, b) {
+    scored = [...scored].sort(function(a, b) {
       return a.score < b.score
     });
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -31,7 +31,6 @@
         "sockjs": "^0.3.24",
         "sockjs-client": "github:jcheng5/sockjs-client#v1.5.2.2-jcheng5",
         "split": "^1.0.1",
-        "stable": "^0.1.8",
         "underscore": "^1.13.2"
       },
       "bin": {
@@ -2862,12 +2861,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility"
-    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -5381,11 +5374,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-    },
-    "stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
     "statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "sockjs": "^0.3.24",
     "sockjs-client": "github:jcheng5/sockjs-client#v1.5.2.2-jcheng5",
     "split": "^1.0.1",
-    "stable": "^0.1.8",
     "underscore": "^1.13.2"
   },
   "license": "AGPL-3.0",


### PR DESCRIPTION
For Node.JS since version 12 sort is already stable, meaning anything released after 2019 is fine (compare https://nodejs.org/en/about/previous-releases).
Note that `package.json` still contains "node>=6.6.0" but `.nvmrc` already uses v18.x.