### PR TITLE
Switch from posit-jenkins credentials to the new posit-jenkins-rstudi…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ def s3_upload(os, arch) {
 
     // Publish the uploaded build to the dailies page (only for builds from
     // master)
-    withCredentials([usernamePassword(credentialsId: 'posit-jenkins', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_PAT')]) {
+    withCredentials([usernamePassword(credentialsId: 'posit-jenkins-rstudio', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_PAT')]) {
         sh "docker/jenkins/publish-build.sh --platform ${os} --url https://s3.amazonaws.com/${bucket}/${os}/${arch}/${file} --pat ${GITHUB_PAT} --file packaging/build/${file}"
     }
   

--- a/Jenkinsfile.internal
+++ b/Jenkinsfile.internal
@@ -62,7 +62,7 @@ def s3_upload(os, arch) {
 
     // Publish the uploaded build to the dailies page (only for builds from
     // master)
-    withCredentials([usernamePassword(credentialsId: 'posit-jenkins', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_PAT')]) {
+    withCredentials([usernamePassword(credentialsId: 'posit-jenkins-rstudio', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_PAT')]) {
         sh "docker/jenkins/publish-build.sh --platform ${os} --url https://s3.amazonaws.com/${bucket}/${os}/${arch}/${file} --pat ${GITHUB_PAT} --file packaging/build/${file}"
     }
   


### PR DESCRIPTION
…o credentials.

We are in the process of deprecating the old `posit-jenkins` credentials.  It is replaced by `posit-jenkins-rstudio`.  The credentials have the exact same permissions, and have been in use for a few weeks in a couple of locations, and since monday across all the jenkins jobs on the jenkins server.  

Changing the references to the credentials in all the various Jenkinsfiles in across many repos in the company is the next step!

This PR accomplishes that goal for the `shiny-server` repo.


Connected to issue https://github.com/rstudio/cloudops/issues/543